### PR TITLE
FB-786

### DIFF
--- a/lib/common/error/index.js
+++ b/lib/common/error/index.js
@@ -1,0 +1,62 @@
+/**
+ * @module CommonError
+ **/
+
+module.exports = class CommonError extends Error {
+  /**
+   * CommonError constructor
+   *
+   * @param {string} message
+   * Error message
+   *
+   * If not passed, will use any value found in options.error.message
+   *
+   * @param {{error: object, data: any}} options
+   * Error options
+   *
+   * @param {object} options.error
+   * Error object or plain object representing an error
+   *
+   * @param {any} options.data
+   * Additional data to attach to the returned error
+   *
+   * @return {CommonError}
+   **/
+  constructor (message, options = {}) {
+    if (typeof message === 'object') {
+      options = message
+      message = undefined
+    }
+
+    const {
+      error,
+      data
+    } = options
+
+    super(error)
+
+    const {
+      constructor,
+      constructor: {
+        name = 'CommonError'
+      }
+    } = this
+
+    if (Error.captureStackTrace) Error.captureStackTrace(this, constructor.bind(this))
+
+    this.name = name
+    this.message = message || options.message
+
+    if (error) {
+      Object
+        .entries(error)
+        .forEach(([key, value]) => {
+          this[key] = value
+        })
+    }
+
+    if (data) {
+      this.data = data
+    }
+  }
+}

--- a/lib/user/jwt/aes256.js
+++ b/lib/user/jwt/aes256.js
@@ -1,8 +1,11 @@
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const crypto = require('crypto')
 const CIPHER_ALGORITHM = 'aes-256-ctr'
 
-const {FBError} = require('@ministryofjustice/fb-utils-node')
-class AES256Error extends FBError {}
+const CommonError = require('~/fb-client/common/error')
+
+class AES256Error extends CommonError {}
 
 /**
    * Encrypt a clear-text message using AES-256 plus an Initialization Vector.

--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -1,3 +1,5 @@
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const got = require('got')
 const jwt = require('jsonwebtoken')
 const pathToRegexp = require('path-to-regexp')
@@ -5,8 +7,9 @@ const crypto = require('crypto')
 
 const aes256 = require('./aes256')
 
-const {FBError} = require('@ministryofjustice/fb-utils-node')
-class ClientError extends FBError {}
+const CommonError = require('~/fb-client/common/error')
+
+class ClientError extends CommonError {}
 
 const getResponseLabels = (response) => {
   const responseLabels = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Form Builder clients for Email, SMS, Submitter, User Data Store, User File Store, and JSON Web Token (for Node)",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
[FB-786](https://dsdmoj.atlassian.net/browse/FB-786) **Create Error classes in the packages which use them**

- Another step toward deprecating `fb-utils-node`

Little/no refactoring. Introduces `CommonError` class into *Client* (formerly `FBError` in `fb-utils-node` with some code-style changes). Additional name changes