### PR TITLE
include subject in jwt if available

### DIFF
--- a/lib/submitter/client.js
+++ b/lib/submitter/client.js
@@ -36,10 +36,11 @@ class SubmitterClient extends Client {
     /* eslint-disable camelcase */
     const service_slug = this.serviceSlug
     const encrypted_user_id_and_token = this.encryptUserIdAndToken(userId, userToken)
+    const subject = userId
     /* eslint-enable camelcase */
 
     const payload = Object.assign(
-      {service_slug, encrypted_user_id_and_token},
+      {service_slug, encrypted_user_id_and_token, subject},
       submission
     )
 

--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -184,9 +184,14 @@ class Client {
    **/
   generateAccessToken (data, secret, algorithm) {
     const checksum = crypto.createHash('sha256').update(JSON.stringify(data)).digest('hex')
+    const subject = data.subject
 
     if (secret) {
-      return jwt.sign({checksum}, secret, {issuer: this.serviceSlug, algorithm: algorithm})
+      if (subject) {
+        return jwt.sign({checksum}, secret, {issuer: this.serviceSlug, subject: subject, algorithm: algorithm})
+      } else {
+        return jwt.sign({checksum}, secret, {issuer: this.serviceSlug, algorithm: algorithm})
+      }
     }
   }
 

--- a/test/lib/submitter/client.spec.js
+++ b/test/lib/submitter/client.spec.js
@@ -215,7 +215,8 @@ describe('~/fb-client/submitter/client', () => {
         url: '/submission',
         payload: {
           encrypted_user_id_and_token: 'mock encrypted user id and token payload',
-          service_slug: 'testServiceSlug'
+          service_slug: 'testServiceSlug',
+          subject: 'mock user id'
         }
       }, mockLogger)
     })

--- a/test/lib/user/jwt/client.spec.js
+++ b/test/lib/user/jwt/client.spec.js
@@ -316,6 +316,23 @@ describe('~/fb-client/user/jwt/client', () => {
                 json: {foo: 'bar'}
               })
           })
+
+          describe('With subject', () => {
+            it('includes subject in jwt', () => {
+              const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, {encodedPrivateKey: encodedPrivateKey})
+
+              expect(client.createRequestOptions('/foo', {}, {foo: 'bar', subject: 'some-guid'}))
+                .to.eql({
+                  url: 'https://microservice/foo',
+                  headers: {
+                    'x-access-token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGVja3N1bSI6IjRhZmRlY2ViM2M5Y2U4MWI2Y2YzZGJhYmY5YzhkZWQ2MmI0MDBhMDI0NzljZjA3ZmY1MjdlNGJkYTQxNTBjZWMiLCJpYXQiOjE0ODMyMjg4MDAsImlzcyI6InRlc3RTZXJ2aWNlU2x1ZyIsInN1YiI6InNvbWUtZ3VpZCJ9.umcTD6ZxVU-ngx20CTro9o8U9fhHfhYIo1qTCd6D5QY',
+                    'x-access-token-v2': 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGVja3N1bSI6IjRhZmRlY2ViM2M5Y2U4MWI2Y2YzZGJhYmY5YzhkZWQ2MmI0MDBhMDI0NzljZjA3ZmY1MjdlNGJkYTQxNTBjZWMiLCJpYXQiOjE0ODMyMjg4MDAsImlzcyI6InRlc3RTZXJ2aWNlU2x1ZyIsInN1YiI6InNvbWUtZ3VpZCJ9.mEVd0chvkwX7JnOGprPDIKpua68zkc3f58JX1U6pA-Y8hIkSUcH-QEc-p0FgUDOVroMJqNh3qnOQ4KVVQyrLMadktceM4i_pVQA_eMsJTfO4EYou0OqCD_MfyuxQPQ-7t9uTLTJydTM-Sez3GNMBEjZz07pML611YWGIHRmPcuFcFWV-wm4LXt_b8oPfThbEqX14h7ugeDkAJThYlRH3SQwsY3_iELjyR09XCyBV-J8cnj6WqLr7cq5sQpVHl_dtToypKOc6EfUga0h15hB4c5o-UmWcMbuyWOBT9pZGuBCvWVlllmZSDlr_F4y2C9ilKv3rGtJvj4EhNkIIP51ArA'
+                  },
+                  responseType: 'json',
+                  json: {foo: 'bar', subject: 'some-guid'}
+                })
+            })
+          })
         })
       })
 


### PR DESCRIPTION
- this adds the user id to payload
- it also adds the user id as the `subject` (`sub`) in the jwt
- subject is only added if `subject` is present in the payload
- these changes affect `x-access-token` and `x-access-token-v2`
- currently the extra subject is not being used by the receiver but will be implemented in the near future