### PR TITLE
encodedPrivateKey can now be added to datastore

### DIFF
--- a/lib/user/datastore/client.js
+++ b/lib/user/datastore/client.js
@@ -31,11 +31,20 @@ class UserDataStoreClient extends Client {
    * @param {string} userDataStoreUrl
    * User datastore URL
    *
+   * @param {string} encodedPrivateKey
+   * Base64 encoded string of RSA private key
+   *
    * @return {object}
    *
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, userDataStoreUrl) {
-    super(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl, UserDataStoreClientError)
+  constructor (serviceSecret, serviceToken, serviceSlug, userDataStoreUrl, encodedPrivateKey) {
+    super(
+      serviceSecret,
+      serviceToken,
+      serviceSlug,
+      userDataStoreUrl,
+      UserDataStoreClientError,
+      {encodedPrivateKey})
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Form Builder clients for Email, SMS, Submitter, User Data Store, User File Store, and JSON Web Token (for Node)",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/lib/user/datastore/client.spec.js
+++ b/test/lib/user/datastore/client.spec.js
@@ -29,10 +29,9 @@ describe('~/fb-client/user/datastore/client', () => {
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-
       it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
-
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
+      it('has no encodedPrivateKey set', () => expect(client.encodedPrivateKey).to.equal(undefined))
 
       it('assigns a default metrics object to the field `apiMetrics`', () => {
         expect(client.apiMetrics).to.be.an('object')
@@ -140,6 +139,13 @@ describe('~/fb-client/user/datastore/client', () => {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
+      })
+    })
+
+    describe('With encodedPrivateKey', () => {
+      it('sets encodedPrivateKey', () => {
+        const client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl, 'some-encoded-private-key')
+        expect(client.encodedPrivateKey).to.equal('some-encoded-private-key')
       })
     })
   })


### PR DESCRIPTION
- this will send `x-access-token-v2` to datastore as a result
- also bumps version