### PR TITLE
Deprecate `eslint-config-fb`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,11 @@
 {
-  "extends": "@ministryofjustice/eslint-config-fb"
+  "extends": "standard",
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module"
+  }
 }

--- a/lib/submitter/client.js
+++ b/lib/submitter/client.js
@@ -18,7 +18,7 @@ class SubmitterClient extends Client {
       serviceSlug,
       submitterUrl,
       SubmitterClientError,
-      {encodedPrivateKey})
+      { encodedPrivateKey })
   }
 
   async getStatus (submissionId, logger) {
@@ -26,7 +26,7 @@ class SubmitterClient extends Client {
 
     return this.sendGet({
       url,
-      context: {submissionId}
+      context: { submissionId }
     }, logger)
   }
 
@@ -40,11 +40,11 @@ class SubmitterClient extends Client {
     /* eslint-enable camelcase */
 
     const payload = Object.assign(
-      {service_slug, encrypted_user_id_and_token},
+      { service_slug, encrypted_user_id_and_token },
       submission
     )
 
-    await this.sendPost({url, payload, subject}, logger)
+    await this.sendPost({ url, payload, subject }, logger)
   }
 }
 

--- a/lib/user/datastore/client.js
+++ b/lib/user/datastore/client.js
@@ -44,7 +44,7 @@ class UserDataStoreClient extends Client {
       serviceSlug,
       userDataStoreUrl,
       UserDataStoreClientError,
-      {encodedPrivateKey})
+      { encodedPrivateKey })
   }
 
   /**
@@ -67,17 +67,17 @@ class UserDataStoreClient extends Client {
    *
    **/
   async getData (args, logger) {
-    const {userId, userToken} = args
+    const { userId, userToken } = args
     const url = endpoints.getData
     const serviceSlug = this.serviceSlug
 
     const json = await this.sendGet({
       url,
-      context: {serviceSlug, userId},
+      context: { serviceSlug, userId },
       subject: userId
     }, logger)
 
-    const {payload} = json
+    const { payload } = json
 
     return this.decrypt(userToken, payload)
   }
@@ -104,7 +104,7 @@ class UserDataStoreClient extends Client {
    *
    **/
   async setData (args, logger) {
-    const {userId, userToken, payload} = args
+    const { userId, userToken, payload } = args
     const url = endpoints.setData
     const serviceSlug = this.serviceSlug
 
@@ -112,8 +112,8 @@ class UserDataStoreClient extends Client {
 
     await this.sendPost({
       url,
-      context: {serviceSlug, userId},
-      payload: {payload: encryptedPayload},
+      context: { serviceSlug, userId },
+      payload: { payload: encryptedPayload },
       subject: userId
     }, logger)
   }

--- a/lib/user/filestore/client.js
+++ b/lib/user/filestore/client.js
@@ -77,7 +77,7 @@ class UserFileStoreClient extends Client {
    * @return {string} url
    */
   getFetchUrl (userId, fingerprint) {
-    return this.createEndpointUrl(endpoints.fetch, {serviceSlug: this.serviceSlug, userId, fingerprint})
+    return this.createEndpointUrl(endpoints.fetch, { serviceSlug: this.serviceSlug, userId, fingerprint })
   }
 
   /**
@@ -103,18 +103,18 @@ class UserFileStoreClient extends Client {
    *
    **/
   async fetch (args, logger) {
-    const {userId, userToken, fingerprint} = args
+    const { userId, userToken, fingerprint } = args
     const url = endpoints.fetch
     const serviceSlug = this.serviceSlug
 
     const encrypted_user_id_and_token = this.encryptUserIdAndToken(userId, userToken) // eslint-disable-line camelcase
 
-    const context = {serviceSlug, userId, fingerprint}
-    const payload = {encrypted_user_id_and_token}
+    const context = { serviceSlug, userId, fingerprint }
+    const payload = { encrypted_user_id_and_token }
     const subject = userId
 
-    const json = await this.sendGet({url, context, payload, subject}, logger)
-    const {file} = json
+    const json = await this.sendGet({ url, context, payload, subject }, logger)
+    const { file } = json
     return Buffer.from(file, 'base64').toString()
   }
 
@@ -152,8 +152,8 @@ class UserFileStoreClient extends Client {
    *
    **/
   async store (args, logger) {
-    const {userId, userToken} = args
-    let {file, policy} = args
+    const { userId, userToken } = args
+    let { file, policy } = args
     const url = endpoints.store
     const serviceSlug = this.serviceSlug
 
@@ -175,11 +175,11 @@ class UserFileStoreClient extends Client {
 
     const encrypted_user_id_and_token = this.encryptUserIdAndToken(userId, userToken) // eslint-disable-line camelcase
 
-    const context = {serviceSlug, userId}
-    const payload = {encrypted_user_id_and_token, file, policy}
+    const context = { serviceSlug, userId }
+    const payload = { encrypted_user_id_and_token, file, policy }
     const subject = userId
 
-    const result = await this.sendPost({url, context, payload, subject}, logger)
+    const result = await this.sendPost({ url, context, payload, subject }, logger)
     // useless if no fingerprint returned
     if (!result.fingerprint) {
       this.throwRequestError(500, 'ENOFINGERPRINT')

--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -192,9 +192,9 @@ class Client {
 
     if (secret) {
       if (subject) {
-        return jwt.sign({checksum}, secret, {issuer: this.serviceSlug, subject: subject, algorithm: algorithm})
+        return jwt.sign({ checksum }, secret, { issuer: this.serviceSlug, subject: subject, algorithm: algorithm })
       } else {
-        return jwt.sign({checksum}, secret, {issuer: this.serviceSlug, algorithm: algorithm})
+        return jwt.sign({ checksum }, secret, { issuer: this.serviceSlug, algorithm: algorithm })
       }
     }
   }
@@ -257,7 +257,7 @@ class Client {
   encryptUserIdAndToken (userId, userToken) {
     const ivSeed = userId + userToken
 
-    return this.encrypt(this.serviceSecret, {userId, userToken}, ivSeed)
+    return this.encrypt(this.serviceSecret, { userId, userToken }, ivSeed)
   }
 
   /**
@@ -360,7 +360,7 @@ class Client {
 
     if ((error.body || false) instanceof Object) error.error = error.body
 
-    const logObject = Object.assign({}, labels, {error})
+    const logObject = Object.assign({}, labels, { error })
 
     /*
      *  This is ugly but at least it's not a single super long line of stupid
@@ -423,7 +423,7 @@ class Client {
     const client = this
     const client_name = this.constructor.name // eslint-disable-line camelcase
     const base_url = this.serviceUrl // eslint-disable-line camelcase
-    const requestOptions = this.createRequestOptions(url, context, payload, method === 'get', {subject})
+    const requestOptions = this.createRequestOptions(url, context, payload, method === 'get', { subject })
 
     const labels = {
       client_name,
@@ -433,7 +433,7 @@ class Client {
     }
 
     function logError (type, error) {
-      client.logError(type, error, Object.assign({}, labels, {name: `jwt_${type.toLowerCase()}_request_error`}), logger)
+      client.logError(type, error, Object.assign({}, labels, { name: `jwt_${type.toLowerCase()}_request_error` }), logger)
     }
 
     let requestMetricsEnd
@@ -472,7 +472,7 @@ class Client {
           }
         ]
       }
-    }, sendOptions, requestOptions, {method})
+    }, sendOptions, requestOptions, { method })
 
     const apiMetricsEnd = this.apiMetrics.startTimer(labels)
 
@@ -492,7 +492,7 @@ class Client {
        */
       return response.body || {}
     } catch (e) {
-      const {response = {}} = e
+      const { response = {} } = e
 
       if (response.statusCode < 300) {
         /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
-      "integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/generator": {
@@ -55,9 +55,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
-      "integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -80,28 +80,6 @@
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.8.3",
         "@babel/types": "^7.8.3"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.8.3"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
@@ -119,34 +97,6 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.8.3"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        }
       }
     },
     "@babel/types": {
@@ -161,9 +111,9 @@
       }
     },
     "@ministryofjustice/module-alias": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.9.tgz",
-      "integrity": "sha512-8WS1JrNVCfwMBQD2y6SBnsnoTSZ57e8CUiu9Vjoiz0A0X09hy39LJHUJPLHREarjvrgL6+tTDvHhlivUAT/wFw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.11.tgz",
+      "integrity": "sha512-hDVvbwKxQ245KWxYC/6+od9llDFS3rjcyPtRGw1LTxhM0Zs3Z5fIXrnNZ34EoUW/14GmLladt3UCpg6x5aL7aA==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -240,9 +190,9 @@
       }
     },
     "@types/node": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
+      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -270,12 +220,12 @@
       "integrity": "sha512-yuaKOdoKebChkP+uRsQovWsJYm6qf58cQTvXBu6MM0BMnrXZ9SXEiXREBuU513ZRr+Uo2qX/Ci6EODLUu/qiHA=="
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -420,22 +370,22 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "cacheable-lookup": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-0.2.1.tgz",
-      "integrity": "sha512-BQ8MRjxJASEq2q+w0SusPU3B054gS278K8sj58QCLMZIso5qG05+MdCdmXxuyVlfvI8h4bPsNOavVUauVCGxrg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-0.2.2.tgz",
+      "integrity": "sha512-+XR+sYSw3gWyyL/4em004eP3RzisWDaGnBPbGpXl4GFSJSiliomxBU9AvStC6W9ivFuDbEcHwuWCEoSqBrK8Ww==",
       "requires": {
-        "keyv": "^3.1.0"
+        "keyv": "^4.0.0"
       }
     },
     "cacheable-request": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.0.tgz",
-      "integrity": "sha512-UVG4gMn3WjnAeFBBx7RFoprgOANIAkMwN5Dta6ONmfSwrCxfm0Ip7g0mIBxIRJZX9aDsoID0Ry3dU5Pr0csKKA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
         "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
+        "keyv": "^4.0.0",
         "lowercase-keys": "^2.0.0",
         "normalize-url": "^4.1.0",
         "responselike": "^2.0.0"
@@ -725,9 +675,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -805,6 +755,15 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "globals": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1080,9 +1039,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1238,13 +1197,10 @@
       }
     },
     "globals": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-      "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.8.1"
-      }
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "got": {
       "version": "10.2.1",
@@ -1365,9 +1321,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -1516,9 +1472,9 @@
       "dev": true
     },
     "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1581,11 +1537,11 @@
       }
     },
     "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
+      "integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
       "requires": {
-        "json-buffer": "3.0.0"
+        "json-buffer": "3.0.1"
       }
     },
     "levn": {
@@ -2246,9 +2202,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,47 @@
         "@babel/highlight": "^7.8.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+      "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/highlight": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
@@ -22,6 +63,101 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+      "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.3",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@ministryofjustice/eslint-config-fb": {
@@ -240,6 +376,20 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1373,6 +1523,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -2269,6 +2425,12 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -2444,6 +2606,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-readable-stream": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,20 +160,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@ministryofjustice/eslint-config-fb": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/eslint-config-fb/-/eslint-config-fb-1.1.8.tgz",
-      "integrity": "sha512-D6gPaBt3QaTsjXTzLt3HcwLvDZqRRkDC4rlcZN06bgPaIxYjHSRgU+UFRSPrtDvW9PRFG6jC9G5fUeli0NuL/Q==",
-      "dev": true,
-      "requires": {
-        "eslint": "^6.8.0",
-        "eslint-config-standard": "^14.1.0",
-        "eslint-plugin-import": "^2.20.0",
-        "eslint-plugin-node": "^11.0.0",
-        "eslint-plugin-promise": "^4.2.1",
-        "eslint-plugin-standard": "^4.0.1"
-      }
-    },
     "@ministryofjustice/module-alias": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.9.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,14 +21,21 @@
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
-    "@ministryofjustice/eslint-config-fb": "^1.1.6",
-    "@ministryofjustice/module-alias": "^1.0.8",
+    "@ministryofjustice/eslint-config-fb": "^1.1.8",
+    "@ministryofjustice/module-alias": "^1.0.9",
+    "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "mocha": "^7.0.0",
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "mocha": "^7.0.1",
     "nock": "^11.7.2",
     "proxyquire": "^2.1.3",
-    "sinon": "^8.0.4",
+    "sinon": "^8.1.1",
     "sinon-chai": "^3.4.0"
   },
   "_moduleAliases": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Form Builder clients for Email, SMS, Submitter, User Data Store, User File Store, and JSON Web Token (for Node)",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
-    "@ministryofjustice/eslint-config-fb": "^1.1.8",
     "@ministryofjustice/module-alias": "^1.0.9",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
-    "@ministryofjustice/module-alias": "^1.0.9",
+    "@ministryofjustice/module-alias": "^1.0.11",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/test/lib/email/client.spec.js
+++ b/test/lib/email/client.spec.js
@@ -62,7 +62,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected name', () => {
           try {
             new EmailClient()
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
         })
@@ -70,7 +70,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected code', () => {
           try {
             new EmailClient()
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESECRET')
           }
         })
@@ -84,7 +84,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected name', () => {
           try {
             new EmailClient(serviceSecret)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
         })
@@ -92,7 +92,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected code', () => {
           try {
             new EmailClient(serviceSecret)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICETOKEN')
           }
         })
@@ -106,7 +106,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected name', () => {
           try {
             new EmailClient(serviceSecret, serviceToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
         })
@@ -114,7 +114,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected code', () => {
           try {
             new EmailClient(serviceSecret, serviceToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
         })
@@ -128,7 +128,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected name', () => {
           try {
             new EmailClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
         })
@@ -136,7 +136,7 @@ describe('~/fb-client/email/client', () => {
         it('has the expected code', () => {
           try {
             new EmailClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
@@ -170,7 +170,7 @@ describe('~/fb-client/email/client', () => {
     })
 
     it('calls `sendPost`', () => {
-      expect(sendPostStub).to.be.calledWith({url: '/email', payload: {message: 'mock message', service_slug: serviceSlug}, sendOptions: mockSendOptions}, mockLogger)
+      expect(sendPostStub).to.be.calledWith({ url: '/email', payload: { message: 'mock message', service_slug: serviceSlug }, sendOptions: mockSendOptions }, mockLogger)
     })
 
     it('returns a `Promise` which resolves to undefined', () => {

--- a/test/lib/sms/client.spec.js
+++ b/test/lib/sms/client.spec.js
@@ -62,7 +62,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected name', () => {
           try {
             new SmsClient()
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
         })
@@ -70,7 +70,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected code', () => {
           try {
             new SmsClient()
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESECRET')
           }
         })
@@ -84,7 +84,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected name', () => {
           try {
             new SmsClient(serviceSecret)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
         })
@@ -92,7 +92,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected code', () => {
           try {
             new SmsClient(serviceSecret)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICETOKEN')
           }
         })
@@ -106,7 +106,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected name', () => {
           try {
             new SmsClient(serviceSecret, serviceToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
         })
@@ -114,7 +114,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected code', () => {
           try {
             new SmsClient(serviceSecret, serviceToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
         })
@@ -128,7 +128,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected name', () => {
           try {
             new SmsClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
         })
@@ -136,7 +136,7 @@ describe('~/fb-client/sms/client', () => {
         it('has the expected code', () => {
           try {
             new SmsClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
@@ -170,7 +170,7 @@ describe('~/fb-client/sms/client', () => {
     })
 
     it('calls `sendPost`', () => {
-      expect(sendPostStub).to.be.calledWith({url: '/sms', payload: {message: 'mock message', service_slug: serviceSlug}, sendOptions: mockSendOptions}, mockLogger)
+      expect(sendPostStub).to.be.calledWith({ url: '/sms', payload: { message: 'mock message', service_slug: serviceSlug }, sendOptions: mockSendOptions }, mockLogger)
     })
 
     it('returns a `Promise` which resolves to undefined', () => {

--- a/test/lib/submitter/client.spec.js
+++ b/test/lib/submitter/client.spec.js
@@ -62,7 +62,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected name', () => {
           try {
             new SubmitterClient()
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
         })
@@ -70,7 +70,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected code', () => {
           try {
             new SubmitterClient()
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESECRET')
           }
         })
@@ -84,7 +84,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected name', () => {
           try {
             new SubmitterClient(serviceSecret)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
         })
@@ -92,7 +92,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected code', () => {
           try {
             new SubmitterClient(serviceSecret)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICETOKEN')
           }
         })
@@ -106,7 +106,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected name', () => {
           try {
             new SubmitterClient(serviceSecret, serviceToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
         })
@@ -114,7 +114,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected code', () => {
           try {
             new SubmitterClient(serviceSecret, serviceToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
         })
@@ -128,7 +128,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected name', () => {
           try {
             new SubmitterClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
         })
@@ -136,7 +136,7 @@ describe('~/fb-client/submitter/client', () => {
         it('has the expected code', () => {
           try {
             new SubmitterClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
@@ -158,7 +158,7 @@ describe('~/fb-client/submitter/client', () => {
 
       sendGetStub = sinon.stub(client, 'sendGet')
 
-      mockSubmissionId = {userId: 'mock user id', userToken: 'mock user token'}
+      mockSubmissionId = { userId: 'mock user id', userToken: 'mock user token' }
       mockLogger = {}
 
       returnValue = await client.getStatus(mockSubmissionId, mockLogger)
@@ -169,7 +169,7 @@ describe('~/fb-client/submitter/client', () => {
     })
 
     it('calls `sendGet`', () => {
-      expect(sendGetStub).to.be.calledWith({url: '/submission/:submissionId', context: {submissionId: mockSubmissionId}}, mockLogger)
+      expect(sendGetStub).to.be.calledWith({ url: '/submission/:submissionId', context: { submissionId: mockSubmissionId } }, mockLogger)
     })
 
     it('returns a `Promise` which resolves to undefined', () => {
@@ -192,7 +192,7 @@ describe('~/fb-client/submitter/client', () => {
 
     beforeEach(async () => {
       client = new SubmitterClient(serviceSecret, serviceToken, serviceSlug, submitterUrl)
-      sendPostStub = sinon.stub(client, 'sendPost').returns({payload: 'mock payload'})
+      sendPostStub = sinon.stub(client, 'sendPost').returns({ payload: 'mock payload' })
       encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns('mock encrypted user id and token payload')
 
       mockSubmission = {}

--- a/test/lib/user/datastore/client.spec.js
+++ b/test/lib/user/datastore/client.spec.js
@@ -61,7 +61,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected name', () => {
           try {
             new UserDataStoreClient()
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
         })
@@ -69,7 +69,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected code', () => {
           try {
             new UserDataStoreClient()
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESECRET')
           }
         })
@@ -83,7 +83,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected name', () => {
           try {
             new UserDataStoreClient(serviceSecret)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
         })
@@ -91,7 +91,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected code', () => {
           try {
             new UserDataStoreClient(serviceSecret)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICETOKEN')
           }
         })
@@ -105,7 +105,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected name', () => {
           try {
             new UserDataStoreClient(serviceSecret, serviceToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
         })
@@ -113,7 +113,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected code', () => {
           try {
             new UserDataStoreClient(serviceSecret, serviceToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
         })
@@ -127,7 +127,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected name', () => {
           try {
             new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
         })
@@ -135,7 +135,7 @@ describe('~/fb-client/user/datastore/client', () => {
         it('has the expected code', () => {
           try {
             new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
@@ -166,10 +166,10 @@ describe('~/fb-client/user/datastore/client', () => {
 
       mockDecryptedData = {}
 
-      sendGetStub = sinon.stub(client, 'sendGet').returns({payload: 'mock payload'})
+      sendGetStub = sinon.stub(client, 'sendGet').returns({ payload: 'mock payload' })
       decryptStub = sinon.stub(client, 'decrypt').returns(mockDecryptedData)
 
-      mockArgs = {userId: 'mock user id', userToken: 'mock user token'}
+      mockArgs = { userId: 'mock user id', userToken: 'mock user token' }
       mockLogger = {}
 
       returnValue = await client.getData(mockArgs, mockLogger)
@@ -213,10 +213,10 @@ describe('~/fb-client/user/datastore/client', () => {
 
     beforeEach(async () => {
       client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl)
-      sendPostStub = sinon.stub(client, 'sendPost').returns({payload: 'mock payload'})
+      sendPostStub = sinon.stub(client, 'sendPost').returns({ payload: 'mock payload' })
       encryptStub = sinon.stub(client, 'encrypt').returns('mock encrypted payload')
 
-      mockArgs = {userId: 'mock user id', userToken: 'mock user token', payload: 'mock payload'}
+      mockArgs = { userId: 'mock user id', userToken: 'mock user token', payload: 'mock payload' }
       mockLogger = {}
 
       returnValue = await client.setData(mockArgs, mockLogger)

--- a/test/lib/user/filestore/client.spec.js
+++ b/test/lib/user/filestore/client.spec.js
@@ -74,7 +74,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected name', () => {
           try {
             new UserFileStoreClient()
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
         })
@@ -82,7 +82,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected code', () => {
           try {
             new UserFileStoreClient()
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESECRET')
           }
         })
@@ -96,7 +96,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected name', () => {
           try {
             new UserFileStoreClient(serviceSecret)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
         })
@@ -104,7 +104,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected code', () => {
           try {
             new UserFileStoreClient(serviceSecret)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICETOKEN')
           }
         })
@@ -118,7 +118,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected name', () => {
           try {
             new UserFileStoreClient(serviceSecret, serviceToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
         })
@@ -126,7 +126,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected code', () => {
           try {
             new UserFileStoreClient(serviceSecret, serviceToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
         })
@@ -140,7 +140,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected name', () => {
           try {
             new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
         })
@@ -148,7 +148,7 @@ describe('~/fb-client/user/filestore/client', () => {
         it('has the expected code', () => {
           try {
             new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
         })
@@ -175,7 +175,7 @@ describe('~/fb-client/user/filestore/client', () => {
     })
 
     it('calls `createEndpointUrl`', () => {
-      expect(createEndpointUrlStub).to.be.calledWith('/service/:serviceSlug/user/:userId/:fingerprint', {serviceSlug, userId: 'mock user id', fingerprint: 'mock fingerprint'})
+      expect(createEndpointUrlStub).to.be.calledWith('/service/:serviceSlug/user/:userId/:fingerprint', { serviceSlug, userId: 'mock user id', fingerprint: 'mock fingerprint' })
     })
 
     it('returns a string', () => {
@@ -195,10 +195,10 @@ describe('~/fb-client/user/filestore/client', () => {
 
     beforeEach(async () => {
       client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
-      encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({payload: 'mock payload'})
-      sendGetStub = sinon.stub(client, 'sendGet').returns({file: Buffer.from('mock file data')})
+      encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({ payload: 'mock payload' })
+      sendGetStub = sinon.stub(client, 'sendGet').returns({ file: Buffer.from('mock file data') })
 
-      mockArgs = {userId: 'mock user id', userToken: 'mock user token', fingerprint: 'mock fingerprint'}
+      mockArgs = { userId: 'mock user id', userToken: 'mock user token', fingerprint: 'mock fingerprint' }
       mockLogger = {}
 
       returnValue = await client.fetch(mockArgs, mockLogger)
@@ -245,10 +245,10 @@ describe('~/fb-client/user/filestore/client', () => {
 
     beforeEach(() => {
       client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
-      encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({payload: 'mock payload'})
+      encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({ payload: 'mock payload' })
       sendPostStub = sinon.stub(client, 'sendPost')
 
-      mockArgs = {userId: 'mock user id', userToken: 'mock user token', file: 'mock file data', policy: {}}
+      mockArgs = { userId: 'mock user id', userToken: 'mock user token', file: 'mock file data', policy: {} }
       mockLogger = {}
     })
 
@@ -259,7 +259,7 @@ describe('~/fb-client/user/filestore/client', () => {
 
     describe('`sendPost` returns an object with a `fingerprint` field', () => {
       beforeEach(async () => {
-        sendPostStub.returns({fingerprint: 'mock fingerprint'})
+        sendPostStub.returns({ fingerprint: 'mock fingerprint' })
       })
 
       it('calls `encryptUserIdAndToken`', async () => {
@@ -273,9 +273,9 @@ describe('~/fb-client/user/filestore/client', () => {
 
         expect(sendPostStub).to.be.calledWith({
           url: '/service/:serviceSlug/user/:userId',
-          context: {serviceSlug, userId: 'mock user id'},
+          context: { serviceSlug, userId: 'mock user id' },
           payload: {
-            encrypted_user_id_and_token: {payload: 'mock payload'},
+            encrypted_user_id_and_token: { payload: 'mock payload' },
             file: 'bW9jayBmaWxlIGRhdGE=',
             policy: {
               max_size: client.maxSize,
@@ -310,9 +310,9 @@ describe('~/fb-client/user/filestore/client', () => {
         } catch (e) {
           expect(sendPostStub).to.be.calledWith({
             url: '/service/:serviceSlug/user/:userId',
-            context: {serviceSlug, userId: 'mock user id'},
+            context: { serviceSlug, userId: 'mock user id' },
             payload: {
-              encrypted_user_id_and_token: {payload: 'mock payload'},
+              encrypted_user_id_and_token: { payload: 'mock payload' },
               file: 'bW9jayBmaWxlIGRhdGE=',
               policy: {
                 max_size: client.maxSize,
@@ -369,7 +369,7 @@ describe('~/fb-client/user/filestore/client', () => {
     })
 
     it('calls `store`', () => {
-      expect(storeStub).to.be.calledWith({file: 'mock file data'}, mockLogger)
+      expect(storeStub).to.be.calledWith({ file: 'mock file data' }, mockLogger)
     })
 
     it('returns a `Promise` which resolves to undefined', () => {

--- a/test/lib/user/jwt/aes256.spec.js
+++ b/test/lib/user/jwt/aes256.spec.js
@@ -29,7 +29,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected name', () => {
           try {
             decrypt(undefined, encryptedData)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('AES256Error')
           }
         })
@@ -37,7 +37,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected code', () => {
           try {
             decrypt(undefined, encryptedData)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENODECRYPTKEY')
           }
         })
@@ -51,7 +51,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected name', () => {
           try {
             decrypt(userToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('AES256Error')
           }
         })
@@ -59,7 +59,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected code', () => {
           try {
             decrypt(userToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENODECRYPTVALUE')
           }
         })
@@ -96,7 +96,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected name', () => {
           try {
             encrypt(undefined, decryptedData)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('AES256Error')
           }
         })
@@ -104,7 +104,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected code', () => {
           try {
             encrypt(undefined, decryptedData)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOENCRYPTKEY')
           }
         })
@@ -118,7 +118,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected name', () => {
           try {
             encrypt(userToken)
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name).to.equal('AES256Error')
           }
         })
@@ -126,7 +126,7 @@ describe('~/fb-client/user/jwt/aes256', () => {
         it('has the expected code', () => {
           try {
             encrypt(userToken)
-          } catch ({code}) {
+          } catch ({ code }) {
             expect(code).to.equal('ENOENCRYPTVALUE')
           }
         })

--- a/test/lib/user/jwt/client.spec.js
+++ b/test/lib/user/jwt/client.spec.js
@@ -90,7 +90,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected name', () => {
             try {
               new Client()
-            } catch ({name}) {
+            } catch ({ name }) {
               expect(name).to.equal('ClientError')
             }
           })
@@ -98,7 +98,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected code', () => {
             try {
               new Client()
-            } catch ({code}) {
+            } catch ({ code }) {
               expect(code).to.equal('ENOSERVICESECRET')
             }
           })
@@ -112,7 +112,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected name', () => {
             try {
               new Client(serviceSecret)
-            } catch ({name}) {
+            } catch ({ name }) {
               expect(name).to.equal('ClientError')
             }
           })
@@ -120,7 +120,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected code', () => {
             try {
               new Client(serviceSecret)
-            } catch ({code}) {
+            } catch ({ code }) {
               expect(code).to.equal('ENOSERVICETOKEN')
             }
           })
@@ -134,7 +134,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected name', () => {
             try {
               new Client(serviceSecret, serviceToken)
-            } catch ({name}) {
+            } catch ({ name }) {
               expect(name).to.equal('ClientError')
             }
           })
@@ -142,7 +142,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected code', () => {
             try {
               new Client(serviceSecret, serviceToken)
-            } catch ({code}) {
+            } catch ({ code }) {
               expect(code).to.equal('ENOSERVICESLUG')
             }
           })
@@ -156,7 +156,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected name', () => {
             try {
               new Client(serviceSecret, serviceToken, serviceSlug)
-            } catch ({name}) {
+            } catch ({ name }) {
               expect(name).to.equal('ClientError')
             }
           })
@@ -164,7 +164,7 @@ describe('~/fb-client/user/jwt/client', () => {
           it('has the expected code', () => {
             try {
               new Client(serviceSecret, serviceToken, serviceSlug)
-            } catch ({code}) {
+            } catch ({ code }) {
               expect(code).to.equal('ENOMICROSERVICEURL')
             }
           })
@@ -202,7 +202,7 @@ describe('~/fb-client/user/jwt/client', () => {
     it('creates the URLs', () => {
       const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
 
-      expect(client.createEndpointUrl('/service/:serviceSlug/user/:userId', {serviceSlug, userId})).to.equal('https://microservice/service/testServiceSlug/user/testUserId')
+      expect(client.createEndpointUrl('/service/:serviceSlug/user/:userId', { serviceSlug, userId })).to.equal('https://microservice/service/testServiceSlug/user/testUserId')
     })
   })
 
@@ -213,8 +213,8 @@ describe('~/fb-client/user/jwt/client', () => {
 
     beforeEach(() => {
       client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
-      clock = sinon.useFakeTimers({now: 1483228800000})
-      accessToken = client.generateAccessToken({data: 'testData'}, serviceToken, 'HS256')
+      clock = sinon.useFakeTimers({ now: 1483228800000 })
+      accessToken = client.generateAccessToken({ data: 'testData' }, serviceToken, 'HS256')
     })
 
     afterEach(() => {
@@ -248,8 +248,8 @@ describe('~/fb-client/user/jwt/client', () => {
 
     beforeEach(() => {
       client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, options)
-      clock = sinon.useFakeTimers({now: 1483228800000})
-      accessToken = client.generateAccessToken({data: 'testData'}, client.privateKey(), 'RS256')
+      clock = sinon.useFakeTimers({ now: 1483228800000 })
+      accessToken = client.generateAccessToken({ data: 'testData' }, client.privateKey(), 'RS256')
     })
 
     afterEach(() => {
@@ -277,7 +277,7 @@ describe('~/fb-client/user/jwt/client', () => {
     let clock
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers({now: 1483228800000})
+      clock = sinon.useFakeTimers({ now: 1483228800000 })
     })
 
     afterEach(() => {
@@ -289,7 +289,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('returns an object with a JSON object assigned to the field `body`', () => {
           const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
 
-          expect(client.createRequestOptions('/foo', {}, {foo: 'bar'}))
+          expect(client.createRequestOptions('/foo', {}, { foo: 'bar' }))
             .to.eql({
               url: 'https://microservice/foo',
               headers: {
@@ -297,15 +297,15 @@ describe('~/fb-client/user/jwt/client', () => {
                 'x-access-token-v2': undefined
               },
               responseType: 'json',
-              json: {foo: 'bar'}
+              json: { foo: 'bar' }
             })
         })
 
         describe('With private key available', () => {
           it('defines x-access-token-v2', () => {
-            const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, {encodedPrivateKey: encodedPrivateKey})
+            const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, { encodedPrivateKey: encodedPrivateKey })
 
-            expect(client.createRequestOptions('/foo', {}, {foo: 'bar'}))
+            expect(client.createRequestOptions('/foo', {}, { foo: 'bar' }))
               .to.eql({
                 url: 'https://microservice/foo',
                 headers: {
@@ -313,15 +313,15 @@ describe('~/fb-client/user/jwt/client', () => {
                   'x-access-token-v2': 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGVja3N1bSI6IjdhMzhiZjgxZjM4M2Y2OTQzM2FkNmU5MDBkMzViM2UyMzg1NTkzZjc2YTdiN2FiNWQ0MzU1YjhiYTQxZWUyNGIiLCJpYXQiOjE0ODMyMjg4MDAsImlzcyI6InRlc3RTZXJ2aWNlU2x1ZyJ9.0w4kIowhP50x84G_4g1PU9ErpcJ1BBY4rUo5sOcyV3wjLviDKhwtPEZEmYgCGM28D00Xt8cWw9ImKDLhCL0CTWu_S1nodyQc1updMdgopWmgDLIfOJrImorx3GbO16o0sVSh3y8K-4ldj4TcUZ_b2RrJx1FZN5wBZ_alKDEihX-mKNpYZ4mpQH8bWVvX-86_JB_MnaCo2ZHyG3SNMQaTHUAQmhsH04K1ECG8_03wIXUWwfhbmqNyaiMlS0PKUubHFD8-6HoC4CQGO7ongmhXbOY_Jxsrkxgmcx9VhAtbAaBmGRJHkO8a5gL0gM2QuhuigIiinxpIOgvLSnCKoaStHA'
                 },
                 responseType: 'json',
-                json: {foo: 'bar'}
+                json: { foo: 'bar' }
               })
           })
 
           describe('With subject', () => {
             it('includes subject in jwt', () => {
-              const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, {encodedPrivateKey: encodedPrivateKey})
+              const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl, undefined, { encodedPrivateKey: encodedPrivateKey })
 
-              expect(client.createRequestOptions('/foo', {}, {foo: 'bar'}, false, {subject: 'some-guid'}))
+              expect(client.createRequestOptions('/foo', {}, { foo: 'bar' }, false, { subject: 'some-guid' }))
                 .to.eql({
                   url: 'https://microservice/foo',
                   headers: {
@@ -329,7 +329,7 @@ describe('~/fb-client/user/jwt/client', () => {
                     'x-access-token-v2': 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGVja3N1bSI6IjdhMzhiZjgxZjM4M2Y2OTQzM2FkNmU5MDBkMzViM2UyMzg1NTkzZjc2YTdiN2FiNWQ0MzU1YjhiYTQxZWUyNGIiLCJpYXQiOjE0ODMyMjg4MDAsImlzcyI6InRlc3RTZXJ2aWNlU2x1ZyIsInN1YiI6InNvbWUtZ3VpZCJ9.AXc2a7wqsz1qJjzoPPIKFfXCNxQI3yz0CpdIkJ2Byj8vw_AnObHEvb6KEgpnEQaHhb-nQgEoVoNoA2DMiQaoEZco79Wv1oiz8IDNjDSX-84z6_Mh7-PvTc0NjLtUtW6mSS-yYMTGDrAL5BNK8vYOvtLxXjvNjcCHOcVfzPEiNpU7GvJsZhpA3f_mvcwpVqYTxa8t0qfgTBsFcpJFxOlEvRglzHLHmtjBIRGfVkcFjZXMVZ5oQiMftWzzSDG6MJLeJJ_4wzp6dwAc-bNw5Jg6sljNc5vEA7LsKc3ABiz7QK4FqTn7iY6C99z1ihRpoDiJ7YVfcvh4XcM97XKtxeHg8w'
                   },
                   responseType: 'json',
-                  json: {foo: 'bar'}
+                  json: { foo: 'bar' }
                 })
             })
           })
@@ -359,7 +359,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('returns an object with a `searchParams` field', () => {
           const client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
 
-          expect(client.createRequestOptions('/foo', {}, {foo: 'bar'}, true))
+          expect(client.createRequestOptions('/foo', {}, { foo: 'bar' }, true))
             .to.eql({
               url: 'https://microservice/foo',
               headers: {
@@ -367,7 +367,7 @@ describe('~/fb-client/user/jwt/client', () => {
                 'x-access-token-v2': undefined
               },
               responseType: 'json',
-              searchParams: {payload: 'eyJmb28iOiJiYXIifQ=='}
+              searchParams: { payload: 'eyJmb28iOiJiYXIifQ==' }
             })
         })
       })
@@ -402,12 +402,12 @@ describe('~/fb-client/user/jwt/client', () => {
       beforeEach(async () => {
         client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
         generateAccessTokenStub = sinon.stub(client, 'generateAccessToken').returns('testAccessToken')
-        getGetStub = sinon.stub(got, 'get').callsFake((options) => Promise.resolve({body: {foo: 'bar'}}))
+        getGetStub = sinon.stub(got, 'get').callsFake((options) => Promise.resolve({ body: { foo: 'bar' } }))
 
         returnValue = await client.sendGet({
           url: '/user/:userId',
-          context: {userId},
-          payload: {foo: 'bar'}
+          context: { userId },
+          payload: { foo: 'bar' }
         })
       })
 
@@ -418,7 +418,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
       it('calls the correct url', () => expect(getGetStub.getCall(0).args[0].url).to.equal(`${microserviceUrl}/user/testUserId`))
       it('adds the correct x-access-token header', () => expect(getGetStub.getCall(0).args[0].headers['x-access-token']).to.equal('testAccessToken'))
-      it('returns the unencrypted data', () => expect(returnValue).to.eql({foo: 'bar'}))
+      it('returns the unencrypted data', () => expect(returnValue).to.eql({ foo: 'bar' }))
     })
 
     describe('Without a payload', () => {
@@ -429,7 +429,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
         returnValue = await client.sendGet({
           url: '/user/:userId',
-          context: {userId}
+          context: { userId }
         })
       })
 
@@ -456,12 +456,12 @@ describe('~/fb-client/user/jwt/client', () => {
       beforeEach(async () => {
         client = new Client(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
         generateAccessTokenStub = sinon.stub(client, 'generateAccessToken').returns('accessToken')
-        getPostStub = sinon.stub(got, 'post').returns(Promise.resolve({body: {foo: 'bar'}}))
+        getPostStub = sinon.stub(got, 'post').returns(Promise.resolve({ body: { foo: 'bar' } }))
 
         returnValue = await client.sendPost({
           url: '/user/:userId',
-          context: {userId},
-          payload: {foo: 'bar'}
+          context: { userId },
+          payload: { foo: 'bar' }
         })
       })
 
@@ -472,7 +472,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
       it('calls the correct url', () => expect(getPostStub.getCall(0).args[0].url).to.equal(`${microserviceUrl}/user/testUserId`))
       it('adds the x-access-token header', () => expect(getPostStub.getCall(0).args[0].headers['x-access-token']).to.equal('accessToken'))
-      it('returns an object', () => expect(returnValue).to.eql({foo: 'bar'}))
+      it('returns an object', () => expect(returnValue).to.eql({ foo: 'bar' }))
     })
 
     describe('Without a payload', () => {
@@ -490,7 +490,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
         returnValue = await client.sendPost({
           url: '/user/:userId',
-          context: {userId}
+          context: { userId }
         })
       })
 
@@ -525,7 +525,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
       nock(microserviceUrl)
         .post('/route')
-        .reply(200, {success: true})
+        .reply(200, { success: true })
 
       await client.send('post', {
         url: '/route'
@@ -544,7 +544,7 @@ describe('~/fb-client/user/jwt/client', () => {
       method: 'post'
     }))
 
-    it('stops the api metrics instrumentation timer with the correct args', () => expect(apiMetricsEndStub.getCall(0).args[0]).to.eql({status_code: 200, status_message: 'OK'}))
+    it('stops the api metrics instrumentation timer with the correct args', () => expect(apiMetricsEndStub.getCall(0).args[0]).to.eql({ status_code: 200, status_message: 'OK' }))
 
     it('starts the request instrumentation timer with the correct args', () => expect(requestMetricsStartTimerStub.getCall(0).args[0]).to.eql({
       client_name: 'Client',
@@ -553,7 +553,7 @@ describe('~/fb-client/user/jwt/client', () => {
       method: 'post'
     }))
 
-    it('stops the request instrumentation timer with the correct args', () => expect(requestMetricsEndStub.getCall(0).args[0]).to.eql({status_code: 200, status_message: 'OK'}))
+    it('stops the request instrumentation timer with the correct args', () => expect(requestMetricsEndStub.getCall(0).args[0]).to.eql({ status_code: 200, status_message: 'OK' }))
   })
 
   describe('Posting to an endpoint unsuccessfully', () => {
@@ -576,7 +576,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
       nock(microserviceUrl)
         .post('/not-found')
-        .reply(404, {code: 404, name: 'ENOTFOUND'})
+        .reply(404, { code: 404, name: 'ENOTFOUND' })
     })
 
     afterEach(() => {
@@ -588,7 +588,7 @@ describe('~/fb-client/user/jwt/client', () => {
       try {
         await client.send('post', {
           url: '/not-found'
-        }, {error: () => {}})
+        }, { error: () => {} })
       } catch (e) {
         expect(e.name).to.equal('ClientError')
       }
@@ -598,7 +598,7 @@ describe('~/fb-client/user/jwt/client', () => {
       try {
         await client.send('post', {
           url: '/not-found'
-        }, {error: () => {}})
+        }, { error: () => {} })
       } catch (e) {
         expect(apiMetricsStartTimerStub.getCall(0).args[0]).to.eql({
           client_name: 'Client',
@@ -613,9 +613,9 @@ describe('~/fb-client/user/jwt/client', () => {
       try {
         await client.send('post', {
           url: '/not-found'
-        }, {error: () => {}})
+        }, { error: () => {} })
       } catch (e) {
-        expect(apiMetricsEndStub.getCall(0).args[0]).to.eql({error_code: 404, error_message: 'Not Found'})
+        expect(apiMetricsEndStub.getCall(0).args[0]).to.eql({ error_code: 404, error_message: 'Not Found' })
       }
     })
 
@@ -623,7 +623,7 @@ describe('~/fb-client/user/jwt/client', () => {
       try {
         await client.send('post', {
           url: '/not-found'
-        }, {error: () => {}})
+        }, { error: () => {} })
       } catch (e) {
         expect(requestMetricsStartTimerStub.getCall(0).args[0]).to.eql({
           client_name: 'Client',
@@ -638,9 +638,9 @@ describe('~/fb-client/user/jwt/client', () => {
       try {
         await client.send('post', {
           url: '/not-found'
-        }, {error: () => {}})
+        }, { error: () => {} })
       } catch (e) {
-        expect(requestMetricsEndStub.getCall(0).args[0]).to.eql({status_code: 404, status_message: 'Not Found'})
+        expect(requestMetricsEndStub.getCall(0).args[0]).to.eql({ status_code: 404, status_message: 'Not Found' })
       }
     })
   })
@@ -674,7 +674,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('throws an ‘ENOTFOUND’', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(e.name).to.equal('ClientError')
       }
@@ -682,7 +682,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('starts the api metrics instrumentation timer with the correct args', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(apiMetricsStartTimerStub.getCall(0).args[0]).to.eql({
           client_name: 'Client',
@@ -695,7 +695,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('stops the api metrics instrumentation timer with the correct args', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(apiMetricsEndStub.getCall(0).args[0]).to.eql({
           error_code: 502,
@@ -706,7 +706,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('starts the request instrumentation timer with the correct args', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(requestMetricsStartTimerStub.getCall(0).args[0]).to.eql({
           client_name: 'Client',
@@ -719,7 +719,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('stops the request instrumentation timer with the correct args', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(requestMetricsEndStub.getCall(0).args[0]).to.eql({
           error_code: 502,
@@ -730,7 +730,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('calls the api metrics start timer the expected number of times', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(apiMetricsStartTimerStub.callCount).to.equal(1)
       }
@@ -738,7 +738,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('calls api metrics end the expected number of times', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(apiMetricsEndStub.callCount).to.equal(1)
       }
@@ -746,7 +746,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('calls request metrics end the expected number of times', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(requestMetricsEndStub.callCount).to.equal(4)
       }
@@ -754,7 +754,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('calls the request metrics start timer the expected number of times', async () => {
       try {
-        await client.send('get', {url: '/server-error', sendOptions: {retry: 3}}, {error (e) { return e }})
+        await client.send('get', { url: '/server-error', sendOptions: { retry: 3 } }, { error (e) { return e } })
       } catch (e) {
         expect(requestMetricsStartTimerStub.callCount).to.equal(4)
       }
@@ -772,11 +772,11 @@ describe('~/fb-client/user/jwt/client', () => {
         it('returns an object', async () => {
           nock(microserviceUrl)
             .get('/json-body')
-            .reply(201, {success: true})
+            .reply(201, { success: true })
 
-          const response = await client.send('get', {url: '/json-body'})
+          const response = await client.send('get', { url: '/json-body' })
 
-          expect(response).to.eql({success: true})
+          expect(response).to.eql({ success: true })
         })
       })
 
@@ -784,11 +784,11 @@ describe('~/fb-client/user/jwt/client', () => {
         it('returns an object', async () => {
           nock(microserviceUrl)
             .post('/json-body')
-            .reply(201, {success: true})
+            .reply(201, { success: true })
 
-          const response = await client.send('post', {url: '/json-body'})
+          const response = await client.send('post', { url: '/json-body' })
 
-          expect(response).to.eql({success: true})
+          expect(response).to.eql({ success: true })
         })
       })
     })
@@ -805,7 +805,7 @@ describe('~/fb-client/user/jwt/client', () => {
             .get('/empty-json-body')
             .reply(201, {})
 
-          const response = await client.send('get', {url: '/empty-json-body'})
+          const response = await client.send('get', { url: '/empty-json-body' })
 
           expect(response).to.eql({})
         })
@@ -817,7 +817,7 @@ describe('~/fb-client/user/jwt/client', () => {
             .post('/empty-json-body')
             .reply(201, {})
 
-          const response = await client.send('post', {url: '/empty-json-body'})
+          const response = await client.send('post', { url: '/empty-json-body' })
 
           expect(response).to.eql({})
         })
@@ -840,7 +840,7 @@ describe('~/fb-client/user/jwt/client', () => {
                 .get('/non-empty-body')
                 .reply(201, ' lorem ipsum ')
 
-              await client.send('get', {url: '/non-empty-body'})
+              await client.send('get', { url: '/non-empty-body' })
             } catch (e) {
               expect(e.name).to.equal('ClientError')
             }
@@ -854,7 +854,7 @@ describe('~/fb-client/user/jwt/client', () => {
                 .post('/non-empty-body')
                 .reply(201, ' lorem ipsum ')
 
-              await client.send('post', {url: '/non-empty-body'})
+              await client.send('post', { url: '/non-empty-body' })
             } catch (e) {
               expect(e.name).to.equal('ClientError')
             }
@@ -870,7 +870,7 @@ describe('~/fb-client/user/jwt/client', () => {
                 .get('/spaces-body')
                 .reply(201, '    ')
 
-              await client.send('get', {url: '/spaces-body'})
+              await client.send('get', { url: '/spaces-body' })
             } catch (e) {
               expect(e.name).to.equal('ClientError')
             }
@@ -884,7 +884,7 @@ describe('~/fb-client/user/jwt/client', () => {
                 .post('/spaces-body')
                 .reply(201, '    ')
 
-              await client.send('post', {url: '/spaces-body'})
+              await client.send('post', { url: '/spaces-body' })
             } catch (e) {
               expect(e.name).to.equal('ClientError')
             }
@@ -905,7 +905,7 @@ describe('~/fb-client/user/jwt/client', () => {
             .get('/empty-string-body')
             .reply(201, '')
 
-          const response = await client.send('get', {url: '/empty-string-body'})
+          const response = await client.send('get', { url: '/empty-string-body' })
 
           expect(response).to.eql({})
         })
@@ -917,7 +917,7 @@ describe('~/fb-client/user/jwt/client', () => {
             .post('/empty-string-body')
             .reply(201, '')
 
-          const response = await client.send('post', {url: '/empty-string-body'})
+          const response = await client.send('post', { url: '/empty-string-body' })
 
           expect(response).to.eql({})
         })
@@ -940,7 +940,7 @@ describe('~/fb-client/user/jwt/client', () => {
           .get('/undefined-body')
           .reply(201)
 
-        const response = await client.send('get', {url: '/undefined-body'})
+        const response = await client.send('get', { url: '/undefined-body' })
 
         expect(response).to.eql({})
       })
@@ -952,7 +952,7 @@ describe('~/fb-client/user/jwt/client', () => {
           .post('/undefined-body')
           .reply(201)
 
-        const response = await client.send('post', {url: '/undefined-body'})
+        const response = await client.send('post', { url: '/undefined-body' })
 
         expect(response).to.eql({})
       })
@@ -1092,7 +1092,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
     it('calls `encrypt()`', () => {
       expect(encryptStub)
-        .to.be.calledWith('mock service secret', {userId: 'mock user id', userToken: 'mock user token'}, 'mock user idmock user token')
+        .to.be.calledWith('mock service secret', { userId: 'mock user id', userToken: 'mock user token' }, 'mock user idmock user token')
     })
 
     it('returns a string', () => {
@@ -1153,8 +1153,8 @@ describe('~/fb-client/user/jwt/client', () => {
             code: 400
           }
 
-          const labels = {client_name: 'Client', method: 'get', base_url: 'https://microservice', url: '/url'}
-          const logger = {error: errorStub}
+          const labels = { client_name: 'Client', method: 'get', base_url: 'https://microservice', url: '/url' }
+          const logger = { error: errorStub }
 
           client.logError(type, error, labels, logger)
         })
@@ -1182,8 +1182,8 @@ describe('~/fb-client/user/jwt/client', () => {
           const type = 'API'
           error = new Error()
 
-          const labels = {client_name: 'Client', method: 'get', base_url: 'https://microservice', url: '/url'}
-          const logger = {error: errorStub}
+          const labels = { client_name: 'Client', method: 'get', base_url: 'https://microservice', url: '/url' }
+          const logger = { error: errorStub }
 
           client.logError(type, error, labels, logger)
         })
@@ -1225,8 +1225,8 @@ describe('~/fb-client/user/jwt/client', () => {
             code: 400
           }
 
-          const labels = {client_name: 'Client', method: 'post', base_url: 'https://microservice', url: '/url'}
-          const logger = {error: errorStub}
+          const labels = { client_name: 'Client', method: 'post', base_url: 'https://microservice', url: '/url' }
+          const logger = { error: errorStub }
 
           client.logError(type, error, labels, logger)
         })
@@ -1254,8 +1254,8 @@ describe('~/fb-client/user/jwt/client', () => {
           const type = 'API'
           error = new Error()
 
-          const labels = {client_name: 'Client', method: 'post', base_url: 'https://microservice', url: '/url'}
-          const logger = {error: errorStub}
+          const labels = { client_name: 'Client', method: 'post', base_url: 'https://microservice', url: '/url' }
+          const logger = { error: errorStub }
 
           client.logError(type, error, labels, logger)
         })
@@ -1373,7 +1373,7 @@ describe('~/fb-client/user/jwt/client', () => {
       describe('The error has a `body` field', () => {
         it('Assigns the value to an `error` field', () => {
           const mockBody = {}
-          const mockError = {body: mockBody}
+          const mockError = { body: mockBody }
 
           client.handleRequestError(mockError)
 
@@ -1385,7 +1385,7 @@ describe('~/fb-client/user/jwt/client', () => {
         describe('400s', () => {
           describe('401', () => {
             it('throws a 401 request error', () => {
-              client.handleRequestError({statusCode: 401})
+              client.handleRequestError({ statusCode: 401 })
 
               expect(throwRequestErrorStub).to.be.calledWith(401)
             })
@@ -1393,7 +1393,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
           describe('403', () => {
             it('throws a 403 request error', () => {
-              client.handleRequestError({statusCode: 403})
+              client.handleRequestError({ statusCode: 403 })
 
               expect(throwRequestErrorStub).to.be.calledWith(403)
             })
@@ -1401,7 +1401,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
           describe('404', () => {
             it('throws a 404 request error', () => {
-              client.handleRequestError({statusCode: 404})
+              client.handleRequestError({ statusCode: 404 })
 
               expect(throwRequestErrorStub).to.be.calledWith(404)
             })
@@ -1412,7 +1412,7 @@ describe('~/fb-client/user/jwt/client', () => {
           describe('The error has an `error` field', () => {
             describe('The object on the error field has a `name` field', () => {
               it('throws a request error with the name', () => {
-                client.handleRequestError({statusCode: 500, error: {name: 'mock name'}})
+                client.handleRequestError({ statusCode: 500, error: { name: 'mock name' } })
 
                 expect(throwRequestErrorStub).to.be.calledWith(500, 'mock name')
               })
@@ -1420,7 +1420,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
             describe('The object on the error field does not have a `name` field but has a `code` field', () => {
               it('throws a request error with the code', () => {
-                client.handleRequestError({statusCode: 500, error: {code: 'mock code'}})
+                client.handleRequestError({ statusCode: 500, error: { code: 'mock code' } })
 
                 expect(throwRequestErrorStub).to.be.calledWith(500, 'mock code')
               })
@@ -1428,7 +1428,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
             describe('The object on the error field has neither a `name` field nor a `code` field', () => {
               it('throws a request error with the default code and the default type', () => {
-                client.handleRequestError({statusCode: 500, error: { }})
+                client.handleRequestError({ statusCode: 500, error: { } })
 
                 expect(throwRequestErrorStub).to.be.calledWith(500, 'EUNSPECIFIED')
               })
@@ -1438,7 +1438,7 @@ describe('~/fb-client/user/jwt/client', () => {
           describe('The error does not have an `error` field', () => {
             describe('The error has a `code` field', () => {
               it('throws a request error with the code', () => {
-                client.handleRequestError({statusCode: 500, code: 'mock code'})
+                client.handleRequestError({ statusCode: 500, code: 'mock code' })
 
                 expect(throwRequestErrorStub).to.be.calledWith(500, 'mock code')
               })
@@ -1446,7 +1446,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
             describe('The error does not have a `code` field', () => {
               it('throws a request error with the default code and the default type', () => {
-                client.handleRequestError({statusCode: 500, error: { }})
+                client.handleRequestError({ statusCode: 500, error: { } })
 
                 expect(throwRequestErrorStub).to.be.calledWith(500, 'EUNSPECIFIED')
               })
@@ -1461,7 +1461,7 @@ describe('~/fb-client/user/jwt/client', () => {
             describe('Mapping the name to a status code', () => {
               describe('The name is `ENOERROR`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {name: 'ENOERROR'}})
+                  client.handleRequestError({ error: { name: 'ENOERROR' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(500, 'ENOERROR')
                 })
@@ -1469,7 +1469,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The name is `ENOTFOUND`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {name: 'ENOTFOUND'}})
+                  client.handleRequestError({ error: { name: 'ENOTFOUND' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(502, 'ENOTFOUND')
                 })
@@ -1477,7 +1477,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The name is `ECONNREFUSED`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {name: 'ECONNREFUSED'}})
+                  client.handleRequestError({ error: { name: 'ECONNREFUSED' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(503, 'ECONNREFUSED')
                 })
@@ -1489,7 +1489,7 @@ describe('~/fb-client/user/jwt/client', () => {
             describe('Mapping the code to a status code', () => {
               describe('The code is `ENOERROR`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {code: 'ENOERROR'}})
+                  client.handleRequestError({ error: { code: 'ENOERROR' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(500, 'ENOERROR')
                 })
@@ -1497,7 +1497,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The code is `ENOTFOUND`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {code: 'ENOTFOUND'}})
+                  client.handleRequestError({ error: { code: 'ENOTFOUND' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(502, 'ENOTFOUND')
                 })
@@ -1505,7 +1505,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The code is `ECONNREFUSED`', () => {
                 it('throws a request error with the name', () => {
-                  client.handleRequestError({error: {code: 'ECONNREFUSED'}})
+                  client.handleRequestError({ error: { code: 'ECONNREFUSED' } })
 
                   expect(throwRequestErrorStub).to.be.calledWith(503, 'ECONNREFUSED')
                 })
@@ -1515,7 +1515,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
           describe('The object on the error field has neither a `name` field nor a `code` field', () => {
             it('throws a request error with the default code and the default type', () => {
-              client.handleRequestError({error: { }})
+              client.handleRequestError({ error: { } })
 
               expect(throwRequestErrorStub).to.be.calledWith(500, 'EUNSPECIFIED')
             })
@@ -1527,7 +1527,7 @@ describe('~/fb-client/user/jwt/client', () => {
             describe('Mapping the code to a status code', () => {
               describe('The code is `ENOERROR`', () => {
                 it('throws a request error with the status code', () => {
-                  client.handleRequestError({code: 'ENOERROR'})
+                  client.handleRequestError({ code: 'ENOERROR' })
 
                   expect(throwRequestErrorStub).to.be.calledWith(500, 'ENOERROR')
                 })
@@ -1535,7 +1535,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The code is `ENOTFOUND`', () => {
                 it('throws a request error with the status code', () => {
-                  client.handleRequestError({code: 'ENOTFOUND'})
+                  client.handleRequestError({ code: 'ENOTFOUND' })
 
                   expect(throwRequestErrorStub).to.be.calledWith(502, 'ENOTFOUND')
                 })
@@ -1543,7 +1543,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The code is `ECONNREFUSED`', () => {
                 it('throws a request error with the status code', () => {
-                  client.handleRequestError({code: 'ECONNREFUSED'})
+                  client.handleRequestError({ code: 'ECONNREFUSED' })
 
                   expect(throwRequestErrorStub).to.be.calledWith(503, 'ECONNREFUSED')
                 })
@@ -1551,7 +1551,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
               describe('The code is not recognised', () => {
                 it('throws a request error with the default status code', () => {
-                  client.handleRequestError({code: 'ENOERROR'})
+                  client.handleRequestError({ code: 'ENOERROR' })
 
                   expect(throwRequestErrorStub).to.be.calledWith(500, 'ENOERROR')
                 })
@@ -1559,7 +1559,7 @@ describe('~/fb-client/user/jwt/client', () => {
             })
 
             it('throws a request error with the code', () => {
-              client.handleRequestError({code: 'mock code'})
+              client.handleRequestError({ code: 'mock code' })
 
               expect(throwRequestErrorStub).to.be.calledWith(500, 'mock code')
             })
@@ -1567,7 +1567,7 @@ describe('~/fb-client/user/jwt/client', () => {
 
           describe('The error does not have a `code` field', () => {
             it('throws a request error with the default code and the default type', () => {
-              client.handleRequestError({error: { }})
+              client.handleRequestError({ error: { } })
 
               expect(throwRequestErrorStub).to.be.calledWith(500, 'EUNSPECIFIED')
             })
@@ -1590,7 +1590,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected name', () => {
           try {
             client.throwRequestError('mock code')
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name)
               .to.equal('ClientError')
           }
@@ -1599,7 +1599,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected code', () => {
           try {
             client.throwRequestError('mock code')
-          } catch ({code}) { // {error: }) {
+          } catch ({ code }) { // {error: }) {
             expect(code)
               .to.equal('mock code')
           }
@@ -1608,7 +1608,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected message', () => {
           try {
             client.throwRequestError('mock code')
-          } catch ({message}) { // {error: }) {
+          } catch ({ message }) { // {error: }) {
             expect(message)
               .to.equal('mock code')
           }
@@ -1623,7 +1623,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected name', () => {
           try {
             client.throwRequestError('mock code', 'mock message')
-          } catch ({name}) {
+          } catch ({ name }) {
             expect(name)
               .to.equal('ClientError')
           }
@@ -1632,7 +1632,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected code', () => {
           try {
             client.throwRequestError('mock code', 'mock message')
-          } catch ({code}) { // {error: }) {
+          } catch ({ code }) { // {error: }) {
             expect(code)
               .to.equal('mock code')
           }
@@ -1641,7 +1641,7 @@ describe('~/fb-client/user/jwt/client', () => {
         it('has the expected message', () => {
           try {
             client.throwRequestError('mock code', 'mock message')
-          } catch ({message}) { // {error: }) {
+          } catch ({ message }) { // {error: }) {
             expect(message)
               .to.equal('mock message')
           }


### PR DESCRIPTION
- Amends `.eslintrc`
- Amends `.editorconfig`
- Removes `eslint-config-fb` from dev dependencies
- Adds separate ESLint dependencies
- Lints with unmodified Standard rules

All changes are whitespace_ around `{` and `}` characters (AR modified the Standard rules to remove the whitespace; I have removed AR's modifications; Standard applies whitespace)