### PR TITLE
Remove v1 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Base client for requests to endpoints which require a JSON Web Token for authent
 const FBJWTClient = require('@ministryofjustice/fb-client/user/jwt/client')
 
 // create a client instance
-const jwtClient = new FBJWTClient(serviceSecret, serviceToken, serviceSlug, microserviceUrl, [errorClass])
+const jwtClient = new FBJWTClient(serviceSecret, serviceSlug, microserviceUrl, [errorClass])
 ```
 
 #### `serviceSecret`
@@ -21,12 +21,6 @@ const jwtClient = new FBJWTClient(serviceSecret, serviceToken, serviceSlug, micr
 A `serviceSecret` is _required_.
 
 The constructor will throw an error if no `serviceSecret` is provided.
-
-#### `serviceToken`
-
-A `serviceToken` is _required_.
-
-The constructor will throw an error if no `serviceToken` is provided.
 
 #### `serviceSlug`
 
@@ -49,23 +43,23 @@ An `errorClass` is _optional_.
 ``` javascript
 // extend base class
 class FBMyClient extends FBJWTClient {
-  constructor (serviceSecret, serviceToken, serviceSlug, microserviceUrl, myVar) {
-    super(serviceSecret, serviceToken, serviceSlug, microserviceUrl)
+  constructor (serviceSecret, serviceSlug, microserviceUrl, myVar) {
+    super(serviceSecret, serviceSlug, microserviceUrl)
     // do something with additional constructor argument
     this.myVar = myVar
   }
 }
 
-const myClient = new FBMyClient('service_secret', 'service_token', 'myservice', 'http://myservice', 'my var')
+const myClient = new FBMyClient('service_secret', 'myservice', 'http://myservice', 'my var')
 ```
 
 ``` javascript
 // extend base class with custom error
 class FBAnotherClient extends FBJWTClient {
-  constructor (serviceSecret, serviceToken, serviceSlug, microserviceUrl) {
+  constructor (serviceSecret, serviceSlug, microserviceUrl) {
     // create custom error class
     class FBAnotherClientError extends FBJWTClient.prototype.ErrorClass {}
-    super(serviceSecret, serviceToken, serviceSlug, microserviceUrl, FBAnotherClientError)
+    super(serviceSecret, serviceSlug, microserviceUrl, FBAnotherClientError)
   }
 }
 ```
@@ -129,7 +123,7 @@ Client for requests to datastore endpoints.
 const FBUserDataStoreClient = require('@ministryofjustice/fb-client/user/datastore/client')
 
 // initialise client
-const userDataStoreClient = new FBUserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl)
+const userDataStoreClient = new FBUserDataStoreClient(serviceSecret, serviceSlug, userDataStoreUrl)
 ```
 
 #### Fetching and storing
@@ -153,7 +147,7 @@ Client for requests to filestore endpoints.
 const FBUserFileStoreClient = require('@ministryofjustice/fb-client/user/filestore/client')
 
 // initialise client
-const userFileStoreClient = new FBUserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+const userFileStoreClient = new FBUserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
 ```
 
 #### Fetching and storing

--- a/lib/email/client.js
+++ b/lib/email/client.js
@@ -15,9 +15,6 @@ class EmailClient extends Client {
    * @param {string} serviceSecret
    * Service secret
    *
-   * @param {string} serviceToken
-   * Service token
-   *
    * @param {string} serviceSlug
    * Service slug
    *
@@ -27,8 +24,8 @@ class EmailClient extends Client {
    * @return {object}
    *
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, emailUrl) {
-    super(serviceSecret, serviceToken, serviceSlug, emailUrl, EmailClientError)
+  constructor (serviceSecret, serviceSlug, emailUrl) {
+    super(serviceSecret, serviceSlug, emailUrl, EmailClientError)
   }
 
   /**

--- a/lib/sms/client.js
+++ b/lib/sms/client.js
@@ -15,9 +15,6 @@ class SmsClient extends Client {
    * @param {string} serviceSecret
    * Service secret
    *
-   * @param {string} serviceToken
-   * Service token
-   *
    * @param {string} serviceSlug
    * Service slug
    *
@@ -27,8 +24,8 @@ class SmsClient extends Client {
    * @return {object}
    *
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, smsUrl) {
-    super(serviceSecret, serviceToken, serviceSlug, smsUrl, SmsClientError)
+  constructor (serviceSecret, serviceSlug, smsUrl) {
+    super(serviceSecret, serviceSlug, smsUrl, SmsClientError)
   }
 
   /**

--- a/lib/submitter/client.js
+++ b/lib/submitter/client.js
@@ -11,10 +11,9 @@ const endpoints = {
 }
 
 class SubmitterClient extends Client {
-  constructor (serviceSecret, serviceToken, serviceSlug, submitterUrl, encodedPrivateKey) {
+  constructor (serviceSecret, serviceSlug, submitterUrl, encodedPrivateKey) {
     super(
       serviceSecret,
-      serviceToken,
       serviceSlug,
       submitterUrl,
       SubmitterClientError,

--- a/lib/submitter/client.js
+++ b/lib/submitter/client.js
@@ -51,7 +51,7 @@ SubmitterClient.offline = () => {
   class SubmitterClientOffline extends SubmitterClient {
     async submit () {}
   }
-  return new SubmitterClientOffline('SERVICE_SECRET', 'SERVICE_TOKEN', 'SERVICE_SLUG', 'SUBMITTER_URL')
+  return new SubmitterClientOffline('SERVICE_SECRET', 'SERVICE_SLUG', 'SUBMITTER_URL')
 }
 
 module.exports = SubmitterClient

--- a/lib/user/datastore/client.js
+++ b/lib/user/datastore/client.js
@@ -22,9 +22,6 @@ class UserDataStoreClient extends Client {
    * @param {string} serviceSecret
    * Service secret
    *
-   * @param {string} serviceToken
-   * Service token
-   *
    * @param {string} serviceSlug
    * Service slug
    *
@@ -37,10 +34,9 @@ class UserDataStoreClient extends Client {
    * @return {object}
    *
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, userDataStoreUrl, encodedPrivateKey) {
+  constructor (serviceSecret, serviceSlug, userDataStoreUrl, encodedPrivateKey) {
     super(
       serviceSecret,
-      serviceToken,
       serviceSlug,
       userDataStoreUrl,
       UserDataStoreClientError,

--- a/lib/user/filestore/client.js
+++ b/lib/user/filestore/client.js
@@ -229,7 +229,7 @@ UserFileStoreClient.offline = function offline () {
     }
   }
 
-  return new UserFileStoreClientOffline('SERVICE_SECRET', 'SERVICE_TOKEN', 'SERVICE_SLUG', 'SUBMITTER_URL')
+  return new UserFileStoreClientOffline('SERVICE_SECRET', 'SERVICE_SLUG', 'SUBMITTER_URL')
 }
 
 module.exports = UserFileStoreClient

--- a/lib/user/filestore/client.js
+++ b/lib/user/filestore/client.js
@@ -29,9 +29,6 @@ class UserFileStoreClient extends Client {
    * @param {string} serviceSecret
    * Service secret
    *
-   * @param {string} serviceToken
-   * Service token
-   *
    * @param {string} serviceSlug
    * Service slug
    *
@@ -51,10 +48,9 @@ class UserFileStoreClient extends Client {
    * @return {object}
    *
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, userFileStoreUrl, options = {}) {
+  constructor (serviceSecret, serviceSlug, userFileStoreUrl, options = {}) {
     super(
       serviceSecret,
-      serviceToken,
       serviceSlug,
       userFileStoreUrl,
       UserFileStoreClientError,

--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -89,9 +89,6 @@ class Client {
    * @param {string} serviceSecret
    * Service secret
    *
-   * @param {string} serviceToken
-   * Service token
-   *
    * @param {string} serviceSlug
    * Service slug
    *
@@ -106,16 +103,13 @@ class Client {
    *
    * @return {object}
    **/
-  constructor (serviceSecret, serviceToken, serviceSlug, microserviceUrl, errorClass, options = {}) {
+  constructor (serviceSecret, serviceSlug, microserviceUrl, errorClass, options = {}) {
     if (errorClass) {
       this.ErrorClass = errorClass
     }
 
     if (!serviceSecret) {
       this.throwRequestError('ENOSERVICESECRET', 'No service secret passed to client')
-    }
-    if (!serviceToken) {
-      this.throwRequestError('ENOSERVICETOKEN', 'No service token passed to client')
     }
     if (!serviceSlug) {
       this.throwRequestError('ENOSERVICESLUG', 'No service slug passed to client')
@@ -125,7 +119,6 @@ class Client {
     }
 
     this.serviceSecret = serviceSecret
-    this.serviceToken = serviceToken
     this.serviceUrl = microserviceUrl
     this.serviceSlug = serviceSlug
     this.encodedPrivateKey = options.encodedPrivateKey
@@ -316,17 +309,13 @@ class Client {
    *
    **/
   createRequestOptions (urlPattern, context, data = {}, isGET, options = {}) {
-    const accessToken = this.generateAccessToken(data, this.serviceToken, 'HS256')
     const accessTokenV2 = this.generateAccessToken(data, this.privateKey(), 'RS256', options)
     const url = this.createEndpointUrl(urlPattern, context)
     const hasData = !!Object.keys(data).length
 
     const requestOptions = {
       url,
-      headers: {
-        'x-access-token': accessToken,
-        'x-access-token-v2': accessTokenV2
-      },
+      headers: { 'x-access-token-v2': accessTokenV2 },
       responseType: 'json'
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "description": "Form Builder clients for Email, SMS, Submitter, User Data Store, User File Store, and JSON Web Token (for Node)",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/lib/email/client.spec.js
+++ b/test/lib/email/client.spec.js
@@ -13,7 +13,6 @@ chai.use(sinonChai)
 const EmailClient = require('~/fb-client/email/client')
 
 const serviceSlug = 'testServiceSlug'
-const serviceToken = 'testServiceToken'
 const serviceSecret = 'testServiceSecret'
 const emailUrl = 'https://email'
 
@@ -25,12 +24,10 @@ describe('~/fb-client/email/client', () => {
       let client
 
       beforeEach(() => {
-        client = new EmailClient(serviceSecret, serviceToken, serviceSlug, emailUrl)
+        client = new EmailClient(serviceSecret, serviceSlug, emailUrl)
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-
-      it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
 
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
 
@@ -77,35 +74,13 @@ describe('~/fb-client/email/client', () => {
       })
     })
 
-    describe('Without a service token parameter', () => {
-      it('throws an error', () => expect(() => new EmailClient(serviceSecret)).to.throw(Error, 'No service token passed to client'))
-
-      describe('The error', () => {
-        it('has the expected name', () => {
-          try {
-            new EmailClient(serviceSecret)
-          } catch ({ name }) {
-            expect(name).to.equal('EmailClientError')
-          }
-        })
-
-        it('has the expected code', () => {
-          try {
-            new EmailClient(serviceSecret)
-          } catch ({ code }) {
-            expect(code).to.equal('ENOSERVICETOKEN')
-          }
-        })
-      })
-    })
-
     describe('Without a service slug parameter', () => {
-      it('throws an error', () => expect(() => new EmailClient(serviceSecret, serviceToken)).to.throw(Error, 'No service slug passed to client'))
+      it('throws an error', () => expect(() => new EmailClient(serviceSecret)).to.throw(Error, 'No service slug passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new EmailClient(serviceSecret, serviceToken)
+            new EmailClient(serviceSecret)
           } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
@@ -113,7 +88,7 @@ describe('~/fb-client/email/client', () => {
 
         it('has the expected code', () => {
           try {
-            new EmailClient(serviceSecret, serviceToken)
+            new EmailClient(serviceSecret)
           } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
@@ -122,12 +97,12 @@ describe('~/fb-client/email/client', () => {
     })
 
     describe('Without an email url parameter', () => {
-      it('throws an error', () => expect(() => new EmailClient(serviceSecret, serviceToken, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
+      it('throws an error', () => expect(() => new EmailClient(serviceSecret, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new EmailClient(serviceSecret, serviceToken, serviceSlug)
+            new EmailClient(serviceSecret, serviceSlug)
           } catch ({ name }) {
             expect(name).to.equal('EmailClientError')
           }
@@ -135,7 +110,7 @@ describe('~/fb-client/email/client', () => {
 
         it('has the expected code', () => {
           try {
-            new EmailClient(serviceSecret, serviceToken, serviceSlug)
+            new EmailClient(serviceSecret, serviceSlug)
           } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
@@ -155,7 +130,7 @@ describe('~/fb-client/email/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new EmailClient(serviceSecret, serviceToken, serviceSlug, emailUrl)
+      client = new EmailClient(serviceSecret, serviceSlug, emailUrl)
       sendPostStub = sinon.stub(client, 'sendPost')
 
       mockMessage = 'mock message'

--- a/test/lib/sms/client.spec.js
+++ b/test/lib/sms/client.spec.js
@@ -13,7 +13,6 @@ chai.use(sinonChai)
 const SmsClient = require('~/fb-client/sms/client')
 
 const serviceSlug = 'testServiceSlug'
-const serviceToken = 'testServiceToken'
 const serviceSecret = 'testServiceSecret'
 const smsUrl = 'https://sms'
 
@@ -25,12 +24,10 @@ describe('~/fb-client/sms/client', () => {
       let client
 
       beforeEach(() => {
-        client = new SmsClient(serviceSecret, serviceToken, serviceSlug, smsUrl)
+        client = new SmsClient(serviceSecret, serviceSlug, smsUrl)
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-
-      it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
 
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
 
@@ -77,35 +74,13 @@ describe('~/fb-client/sms/client', () => {
       })
     })
 
-    describe('Without a service token parameter', () => {
-      it('throws an error', () => expect(() => new SmsClient(serviceSecret)).to.throw(Error, 'No service token passed to client'))
-
-      describe('The error', () => {
-        it('has the expected name', () => {
-          try {
-            new SmsClient(serviceSecret)
-          } catch ({ name }) {
-            expect(name).to.equal('SmsClientError')
-          }
-        })
-
-        it('has the expected code', () => {
-          try {
-            new SmsClient(serviceSecret)
-          } catch ({ code }) {
-            expect(code).to.equal('ENOSERVICETOKEN')
-          }
-        })
-      })
-    })
-
     describe('Without a service slug parameter', () => {
-      it('throws an error', () => expect(() => new SmsClient(serviceSecret, serviceToken)).to.throw(Error, 'No service slug passed to client'))
+      it('throws an error', () => expect(() => new SmsClient(serviceSecret)).to.throw(Error, 'No service slug passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new SmsClient(serviceSecret, serviceToken)
+            new SmsClient(serviceSecret)
           } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
@@ -113,7 +88,7 @@ describe('~/fb-client/sms/client', () => {
 
         it('has the expected code', () => {
           try {
-            new SmsClient(serviceSecret, serviceToken)
+            new SmsClient(serviceSecret)
           } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
@@ -122,12 +97,12 @@ describe('~/fb-client/sms/client', () => {
     })
 
     describe('Without an sms url parameter', () => {
-      it('throws an error', () => expect(() => new SmsClient(serviceSecret, serviceToken, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
+      it('throws an error', () => expect(() => new SmsClient(serviceSecret, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new SmsClient(serviceSecret, serviceToken, serviceSlug)
+            new SmsClient(serviceSecret, serviceSlug)
           } catch ({ name }) {
             expect(name).to.equal('SmsClientError')
           }
@@ -135,7 +110,7 @@ describe('~/fb-client/sms/client', () => {
 
         it('has the expected code', () => {
           try {
-            new SmsClient(serviceSecret, serviceToken, serviceSlug)
+            new SmsClient(serviceSecret, serviceSlug)
           } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
@@ -155,7 +130,7 @@ describe('~/fb-client/sms/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new SmsClient(serviceSecret, serviceToken, serviceSlug, smsUrl)
+      client = new SmsClient(serviceSecret, serviceSlug, smsUrl)
       sendPostStub = sinon.stub(client, 'sendPost')
 
       mockMessage = 'mock message'

--- a/test/lib/submitter/client.spec.js
+++ b/test/lib/submitter/client.spec.js
@@ -13,7 +13,6 @@ chai.use(sinonChai)
 const SubmitterClient = require('~/fb-client/submitter/client')
 
 const serviceSlug = 'testServiceSlug'
-const serviceToken = 'testServiceToken'
 const serviceSecret = 'testServiceSecret'
 const submitterUrl = 'https://submitter'
 
@@ -25,12 +24,10 @@ describe('~/fb-client/submitter/client', () => {
       let client
 
       beforeEach(() => {
-        client = new SubmitterClient(serviceSecret, serviceToken, serviceSlug, submitterUrl)
+        client = new SubmitterClient(serviceSecret, serviceSlug, submitterUrl)
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-
-      it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
 
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
 
@@ -77,35 +74,13 @@ describe('~/fb-client/submitter/client', () => {
       })
     })
 
-    describe('Without a service token parameter', () => {
-      it('throws an error', () => expect(() => new SubmitterClient(serviceSecret)).to.throw(Error, 'No service token passed to client'))
-
-      describe('The error', () => {
-        it('has the expected name', () => {
-          try {
-            new SubmitterClient(serviceSecret)
-          } catch ({ name }) {
-            expect(name).to.equal('SubmitterClientError')
-          }
-        })
-
-        it('has the expected code', () => {
-          try {
-            new SubmitterClient(serviceSecret)
-          } catch ({ code }) {
-            expect(code).to.equal('ENOSERVICETOKEN')
-          }
-        })
-      })
-    })
-
     describe('Without a service slug parameter', () => {
-      it('throws an error', () => expect(() => new SubmitterClient(serviceSecret, serviceToken)).to.throw(Error, 'No service slug passed to client'))
+      it('throws an error', () => expect(() => new SubmitterClient(serviceSecret)).to.throw(Error, 'No service slug passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new SubmitterClient(serviceSecret, serviceToken)
+            new SubmitterClient(serviceSecret)
           } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
@@ -113,7 +88,7 @@ describe('~/fb-client/submitter/client', () => {
 
         it('has the expected code', () => {
           try {
-            new SubmitterClient(serviceSecret, serviceToken)
+            new SubmitterClient(serviceSecret)
           } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
@@ -122,12 +97,12 @@ describe('~/fb-client/submitter/client', () => {
     })
 
     describe('Without a service url parameter', () => {
-      it('throws an error', () => expect(() => new SubmitterClient(serviceSecret, serviceToken, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
+      it('throws an error', () => expect(() => new SubmitterClient(serviceSecret, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new SubmitterClient(serviceSecret, serviceToken, serviceSlug)
+            new SubmitterClient(serviceSecret, serviceSlug)
           } catch ({ name }) {
             expect(name).to.equal('SubmitterClientError')
           }
@@ -135,7 +110,7 @@ describe('~/fb-client/submitter/client', () => {
 
         it('has the expected code', () => {
           try {
-            new SubmitterClient(serviceSecret, serviceToken, serviceSlug)
+            new SubmitterClient(serviceSecret, serviceSlug)
           } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
@@ -154,7 +129,7 @@ describe('~/fb-client/submitter/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new SubmitterClient(serviceSecret, serviceToken, serviceSlug, submitterUrl)
+      client = new SubmitterClient(serviceSecret, serviceSlug, submitterUrl)
 
       sendGetStub = sinon.stub(client, 'sendGet')
 
@@ -191,7 +166,7 @@ describe('~/fb-client/submitter/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new SubmitterClient(serviceSecret, serviceToken, serviceSlug, submitterUrl)
+      client = new SubmitterClient(serviceSecret, serviceSlug, submitterUrl)
       sendPostStub = sinon.stub(client, 'sendPost').returns({ payload: 'mock payload' })
       encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns('mock encrypted user id and token payload')
 

--- a/test/lib/user/datastore/client.spec.js
+++ b/test/lib/user/datastore/client.spec.js
@@ -13,7 +13,6 @@ chai.use(sinonChai)
 const UserDataStoreClient = require('~/fb-client/user/datastore/client')
 
 const serviceSlug = 'testServiceSlug'
-const serviceToken = 'testServiceToken'
 const serviceSecret = 'testServiceSecret'
 const userDataStoreUrl = 'https://userdatastore'
 
@@ -25,11 +24,10 @@ describe('~/fb-client/user/datastore/client', () => {
       let client
 
       beforeEach(() => {
-        client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl)
+        client = new UserDataStoreClient(serviceSecret, serviceSlug, userDataStoreUrl)
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-      it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
       it('has no encodedPrivateKey set', () => expect(client.encodedPrivateKey).to.equal(undefined))
 
@@ -76,35 +74,13 @@ describe('~/fb-client/user/datastore/client', () => {
       })
     })
 
-    describe('Without a service token parameter', () => {
-      it('throws an error', () => expect(() => new UserDataStoreClient(serviceSecret)).to.throw(Error, 'No service token passed to client'))
-
-      describe('The error', () => {
-        it('has the expected name', () => {
-          try {
-            new UserDataStoreClient(serviceSecret)
-          } catch ({ name }) {
-            expect(name).to.equal('UserDataStoreClientError')
-          }
-        })
-
-        it('has the expected code', () => {
-          try {
-            new UserDataStoreClient(serviceSecret)
-          } catch ({ code }) {
-            expect(code).to.equal('ENOSERVICETOKEN')
-          }
-        })
-      })
-    })
-
     describe('Without a service slug parameter', () => {
-      it('throws an error', () => expect(() => new UserDataStoreClient(serviceSecret, serviceToken)).to.throw(Error, 'No service slug passed to client'))
+      it('throws an error', () => expect(() => new UserDataStoreClient(serviceSecret)).to.throw(Error, 'No service slug passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new UserDataStoreClient(serviceSecret, serviceToken)
+            new UserDataStoreClient(serviceSecret)
           } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
@@ -112,7 +88,7 @@ describe('~/fb-client/user/datastore/client', () => {
 
         it('has the expected code', () => {
           try {
-            new UserDataStoreClient(serviceSecret, serviceToken)
+            new UserDataStoreClient(serviceSecret)
           } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
@@ -121,12 +97,12 @@ describe('~/fb-client/user/datastore/client', () => {
     })
 
     describe('Without a service url parameter', () => {
-      it('throws an error', () => expect(() => new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
+      it('throws an error', () => expect(() => new UserDataStoreClient(serviceSecret, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug)
+            new UserDataStoreClient(serviceSecret, serviceSlug)
           } catch ({ name }) {
             expect(name).to.equal('UserDataStoreClientError')
           }
@@ -134,7 +110,7 @@ describe('~/fb-client/user/datastore/client', () => {
 
         it('has the expected code', () => {
           try {
-            new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug)
+            new UserDataStoreClient(serviceSecret, serviceSlug)
           } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
@@ -144,7 +120,7 @@ describe('~/fb-client/user/datastore/client', () => {
 
     describe('With encodedPrivateKey', () => {
       it('sets encodedPrivateKey', () => {
-        const client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl, 'some-encoded-private-key')
+        const client = new UserDataStoreClient(serviceSecret, serviceSlug, userDataStoreUrl, 'some-encoded-private-key')
         expect(client.encodedPrivateKey).to.equal('some-encoded-private-key')
       })
     })
@@ -162,7 +138,7 @@ describe('~/fb-client/user/datastore/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl)
+      client = new UserDataStoreClient(serviceSecret, serviceSlug, userDataStoreUrl)
 
       mockDecryptedData = {}
 
@@ -212,7 +188,7 @@ describe('~/fb-client/user/datastore/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new UserDataStoreClient(serviceSecret, serviceToken, serviceSlug, userDataStoreUrl)
+      client = new UserDataStoreClient(serviceSecret, serviceSlug, userDataStoreUrl)
       sendPostStub = sinon.stub(client, 'sendPost').returns({ payload: 'mock payload' })
       encryptStub = sinon.stub(client, 'encrypt').returns('mock encrypted payload')
 

--- a/test/lib/user/filestore/client.spec.js
+++ b/test/lib/user/filestore/client.spec.js
@@ -25,7 +25,6 @@ const UserFileStoreClient = proxyquire('~/fb-client/user/filestore/client', {
 })
 
 const serviceSlug = 'testServiceSlug'
-const serviceToken = 'testServiceToken'
 const serviceSecret = 'testServiceSecret'
 const userFileStoreUrl = 'https://userfilestore'
 
@@ -37,12 +36,10 @@ describe('~/fb-client/user/filestore/client', () => {
       let client
 
       beforeEach(() => {
-        client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+        client = new UserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
       })
 
       it('assigns the service secret to a field of the instance', () => expect(client.serviceSecret).to.equal(serviceSecret))
-
-      it('assigns the service token to a field of the instance', () => expect(client.serviceToken).to.equal(serviceToken))
 
       it('assigns the service slug to a field of the instance', () => expect(client.serviceSlug).to.equal(serviceSlug))
 
@@ -89,35 +86,13 @@ describe('~/fb-client/user/filestore/client', () => {
       })
     })
 
-    describe('Without a service token parameter', () => {
-      it('throws an error', () => expect(() => new UserFileStoreClient(serviceSecret)).to.throw(Error, 'No service token passed to client'))
-
-      describe('The error', () => {
-        it('has the expected name', () => {
-          try {
-            new UserFileStoreClient(serviceSecret)
-          } catch ({ name }) {
-            expect(name).to.equal('UserFileStoreClientError')
-          }
-        })
-
-        it('has the expected code', () => {
-          try {
-            new UserFileStoreClient(serviceSecret)
-          } catch ({ code }) {
-            expect(code).to.equal('ENOSERVICETOKEN')
-          }
-        })
-      })
-    })
-
     describe('Without a service slug parameter', () => {
-      it('throws an error', () => expect(() => new UserFileStoreClient(serviceSecret, serviceToken)).to.throw(Error, 'No service slug passed to client'))
+      it('throws an error', () => expect(() => new UserFileStoreClient(serviceSecret)).to.throw(Error, 'No service slug passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new UserFileStoreClient(serviceSecret, serviceToken)
+            new UserFileStoreClient(serviceSecret)
           } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
@@ -125,7 +100,7 @@ describe('~/fb-client/user/filestore/client', () => {
 
         it('has the expected code', () => {
           try {
-            new UserFileStoreClient(serviceSecret, serviceToken)
+            new UserFileStoreClient(serviceSecret)
           } catch ({ code }) {
             expect(code).to.equal('ENOSERVICESLUG')
           }
@@ -134,12 +109,12 @@ describe('~/fb-client/user/filestore/client', () => {
     })
 
     describe('Without a service url parameter', () => {
-      it('throws an error', () => expect(() => new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
+      it('throws an error', () => expect(() => new UserFileStoreClient(serviceSecret, serviceSlug)).to.throw(Error, 'No microservice url passed to client'))
 
       describe('The error', () => {
         it('has the expected name', () => {
           try {
-            new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug)
+            new UserFileStoreClient(serviceSecret, serviceSlug)
           } catch ({ name }) {
             expect(name).to.equal('UserFileStoreClientError')
           }
@@ -147,7 +122,7 @@ describe('~/fb-client/user/filestore/client', () => {
 
         it('has the expected code', () => {
           try {
-            new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug)
+            new UserFileStoreClient(serviceSecret, serviceSlug)
           } catch ({ code }) {
             expect(code).to.equal('ENOMICROSERVICEURL')
           }
@@ -163,7 +138,7 @@ describe('~/fb-client/user/filestore/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+      client = new UserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
 
       createEndpointUrlStub = sinon.stub(client, 'createEndpointUrl').returns('mock endpoint url')
 
@@ -194,7 +169,7 @@ describe('~/fb-client/user/filestore/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+      client = new UserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
       encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({ payload: 'mock payload' })
       sendGetStub = sinon.stub(client, 'sendGet').returns({ file: Buffer.from('mock file data') })
 
@@ -244,7 +219,7 @@ describe('~/fb-client/user/filestore/client', () => {
     let mockLogger
 
     beforeEach(() => {
-      client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+      client = new UserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
       encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns({ payload: 'mock payload' })
       sendPostStub = sinon.stub(client, 'sendPost')
 
@@ -348,7 +323,7 @@ describe('~/fb-client/user/filestore/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new UserFileStoreClient(serviceSecret, serviceToken, serviceSlug, userFileStoreUrl)
+      client = new UserFileStoreClient(serviceSecret, serviceSlug, userFileStoreUrl)
       readFileStub.returns('mock file data')
       storeStub = sinon.stub(client, 'store')
 


### PR DESCRIPTION
Client authentication is now done via a JWT set in the `x-access-token-v2` header. Therefore we can now remove the `x-access-token` code and related tests.

https://trello.com/c/DaEXYM24/109-switch-to-new-auth-method-deprecate-old-auth-method-4-4

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>