### PR TITLE
Access error messages from nested responses

### DIFF
--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -4,6 +4,7 @@ const got = require('got')
 const jwt = require('jsonwebtoken')
 const pathToRegexp = require('path-to-regexp')
 const crypto = require('crypto')
+const _ = require('lodash')
 
 const debug = require('debug')
 const log = debug('client:user:jwt')
@@ -627,6 +628,12 @@ class Client {
       // Handle errors which have an error object
       const message = e.error.name || e.error.code || 'EUNSPECIFIED'
       this.throwRequestError(getErrorStatusCode(message), message, response)
+    } else if (_.has(response, 'response.body')) {
+      // Nested response object
+      const body = _.get(response, 'response.body')
+      const message = _.get(body, 'name', 'ENOERROR')
+      const code = _.get(body, 'code', getErrorStatusCode(message))
+      this.throwRequestError(code, message, response)
     } else {
       // Handle errors which have no error object
       const message = e.code || 'ENOERROR'

--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -607,38 +607,42 @@ class Client {
       statusCode
     } = e
 
+    let message
+    let code
     if (statusCode) {
       log(statusCode)
 
       if (statusCode > 400 && statusCode < 500) {
         // Data does not exist - ie. expired
-        this.throwRequestError(statusCode, statusCode, response)
+        message = statusCode
+        code = statusCode
       } else {
         if (e.error) {
           // Handle errors which have an error object
-          const message = e.error.name || e.error.code || 'EUNSPECIFIED'
-          this.throwRequestError(statusCode, message, response)
+          message = e.error.name || e.error.code || 'EUNSPECIFIED'
+          code = statusCode
         } else {
           // Handle errors which have no error object
-          const message = e.code || 'ENOERROR'
-          this.throwRequestError(statusCode, message, response)
+          message = e.code || 'ENOERROR'
+          code = statusCode
         }
       }
     } else if (e.error) {
       // Handle errors which have an error object
-      const message = e.error.name || e.error.code || 'EUNSPECIFIED'
-      this.throwRequestError(getErrorStatusCode(message), message, response)
+      message = e.error.name || e.error.code || 'EUNSPECIFIED'
+      code = getErrorStatusCode(message)
     } else if (_.has(response, 'response.body')) {
       // Nested response object
       const body = _.get(response, 'response.body')
-      const message = _.get(body, 'name', 'ENOERROR')
-      const code = _.get(body, 'code', getErrorStatusCode(message))
-      this.throwRequestError(code, message, response)
+      message = _.get(body, 'name', 'ENOERROR')
+      code = _.get(body, 'code', getErrorStatusCode(message))
     } else {
       // Handle errors which have no error object
-      const message = e.code || 'ENOERROR'
-      this.throwRequestError(getErrorStatusCode(message), message, response)
+      message = e.code || 'ENOERROR'
+      code = getErrorStatusCode(message)
     }
+
+    this.throwRequestError(code, message, response)
   }
 
   /**

--- a/test/lib/user/jwt/client.spec.js
+++ b/test/lib/user/jwt/client.spec.js
@@ -1569,6 +1569,37 @@ describe('~/fb-client/user/jwt/client', () => {
             })
           })
         })
+
+        describe('There is a nested response object', () => {
+          describe('There are name and code fields in the response body object', () => {
+            it('throws a request error with the code and message from the response body object', () => {
+              const errorResponse = {
+                response: {
+                  body: {
+                    code: 400,
+                    name: 'accept' // 'accept' used for unsupported file type validations ¯\_(ツ)_/¯
+                  }
+                }
+              }
+              client.handleRequestError({}, errorResponse)
+
+              expect(throwRequestErrorStub).to.be.calledWith(400, 'accept')
+            })
+          })
+
+          describe('There are no name or code fields in the response body object', () => {
+            it('throws a request error with the default values', () => {
+              const errorResponse = {
+                response: {
+                  body: {}
+                }
+              }
+              client.handleRequestError({}, errorResponse)
+
+              expect(throwRequestErrorStub).to.be.calledWith(500, 'ENOERROR')
+            })
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
# Access error messages from nested responses

Some responses from the filestore will return a nested response which can contain fields whose values are used to present the correct validation error message to a user.

For example, when there is a validation error on a file upload as a result of the file being an unsupported type, the response from the filestore will be parsed into an error object that has further response body field containing a 'name' field. For unsupported file types the value of this will be 'accept' ( ¯\_(ツ)_/¯ ). This value maps to custom error messages which can be created by the form owners to be shown to their end users.

Here we attempt to retrieve the necessary values, but fall back to defaults if we are unable to do so.

# Refactor the handling of error requests method a bit

Swap it to have a single exit point

# Before

<img width="994" alt="Screenshot 2020-05-27 at 21 17 09" src="https://user-images.githubusercontent.com/3466862/83068002-7a27fe00-a05f-11ea-808e-afad27a6cbdf.png">

# After

<img width="989" alt="Screenshot 2020-05-27 at 17 01 58" src="https://user-images.githubusercontent.com/3466862/83062300-54e2c200-a056-11ea-9c92-2f30d6e0e3b8.png">

https://trello.com/c/S1HitJqG/462-bug-investigation-prod-investigate-error-thrown-by-uploading-csv-ppt-xls-files-in-hmcts-complaints-form