### PR TITLE
Encrypt the submission when sending to Submitter

### DIFF
--- a/lib/submitter/client.js
+++ b/lib/submitter/client.js
@@ -11,8 +11,9 @@ const endpoints = {
 }
 
 class SubmitterClient extends Client {
-  constructor (serviceSecret, serviceSlug, submitterUrl, encodedPrivateKey) {
+  constructor (serviceSecret, serviceSlug, submitterUrl, encodedPrivateKey, submissionEncryptionKey) {
     super(serviceSecret, serviceSlug, submitterUrl, SubmitterClientError, encodedPrivateKey)
+    this.submissionEncryptionKey = submissionEncryptionKey
   }
 
   async getStatus (submissionId, logger) {
@@ -33,9 +34,13 @@ class SubmitterClient extends Client {
     const subject = userId
     /* eslint-enable camelcase */
 
+    const encryptedSubmission = {
+      encrypted_submission: this.encrypt(this.submissionEncryptionKey, submission)
+    }
+
     const payload = Object.assign(
       { service_slug, encrypted_user_id_and_token },
-      submission
+      encryptedSubmission
     )
 
     await this.sendPost({ url, payload, subject }, logger)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "engines": {
     "node": ">=14.5.0"
   },

--- a/test/lib/submitter/client.spec.js
+++ b/test/lib/submitter/client.spec.js
@@ -156,9 +156,12 @@ describe('~/fb-client/submitter/client', () => {
     let client
     let sendPostStub
     let encryptUserIdAndTokenStub
+    let encryptSubmission
 
     const mockUserId = 'mock user id'
     const mockUserToken = 'mock user token'
+    const encodedPrivateKey = 'encryped private key'
+    const submissionEncryptionKey = 'submission encryption key'
 
     let mockSubmission
     let mockLogger
@@ -166,9 +169,10 @@ describe('~/fb-client/submitter/client', () => {
     let returnValue
 
     beforeEach(async () => {
-      client = new SubmitterClient(serviceSecret, serviceSlug, submitterUrl)
+      client = new SubmitterClient(serviceSecret, serviceSlug, submitterUrl, encodedPrivateKey, submissionEncryptionKey)
       sendPostStub = sinon.stub(client, 'sendPost').returns({ payload: 'mock payload' })
       encryptUserIdAndTokenStub = sinon.stub(client, 'encryptUserIdAndToken').returns('mock encrypted user id and token payload')
+      encryptSubmission = sinon.stub(client, 'encrypt').returns('encrypted submission')
 
       mockSubmission = {}
       mockLogger = {}
@@ -183,6 +187,7 @@ describe('~/fb-client/submitter/client', () => {
 
     it('calls `encryptUserIdAndToken`', () => {
       expect(encryptUserIdAndTokenStub).to.be.calledWith('mock user id', 'mock user token')
+      expect(encryptSubmission).to.be.calledWith(submissionEncryptionKey, mockSubmission)
     })
 
     it('calls `sendPost`', () => {
@@ -190,7 +195,8 @@ describe('~/fb-client/submitter/client', () => {
         url: '/submission',
         payload: {
           encrypted_user_id_and_token: 'mock encrypted user id and token payload',
-          service_slug: 'testServiceSlug'
+          service_slug: 'testServiceSlug',
+          encrypted_submission: 'encrypted submission'
         },
         subject: 'mock user id'
       }, mockLogger)


### PR DESCRIPTION
We need to encrypt the actual submission itself when sending a submission payload to the Submitter.

We chose the similar method to how the user session and token are submitted which coincidentally is also similar to how JSON payloads are encrypted between the Submitter and the Base Adapter.

https://trello.com/c/j6VCPRja/806-encrypt-between-the-runner-the-submitter

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>