### PR TITLE
Increase timeout on requests

### DIFF
--- a/lib/user/jwt/client.js
+++ b/lib/user/jwt/client.js
@@ -444,6 +444,8 @@ class Client {
     let retryCounter = 1
 
     const gotOptions = got.mergeOptions(got.defaults.options, {
+      timeout: 30,
+      retry: { limit: 3, methods: ['GET', 'POST'] },
       hooks: {
         beforeRequest: [
           () => {


### PR DESCRIPTION
This is to help mitigate with errors that seem to be happening with requests to the datastore and to the filestore when there are concurrent users on the platform.

This is by no means a proper solution, but will help in the short term.

https://trello.com/c/ZsrGougQ/974-increase-request-timeout-in-fb-client