### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       }
     },
     "@ministryofjustice/module-alias": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.18.tgz",
-      "integrity": "sha512-hj0GkR3QFn+YPS2cU5o6ioisd2uethBIfpGYa5SMTXmtDBavUhdrGRP1v707sI/mCfsfDlG/bOa/r109DRPSAQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.19.tgz",
+      "integrity": "sha512-+f51eTz+x9XkMxjXWSj+/Bg6mxOglr0d3jkVxr51/S2n8q6Xw+NSXvcwd41LkGc1sQTZQxt4F1K+lX4BWmsfgw==",
       "dev": true
     },
     "@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
-    "@ministryofjustice/module-alias": "^1.0.18",
+    "@ministryofjustice/module-alias": "^1.0.19",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "engines": {
     "node": ">=14.5.0"
   },


### PR DESCRIPTION
This PR bumps module alas version to 1.0.19 and fb-client version to 2.1.2