### PR TITLE
Bump 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-client",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "engines": {
     "node": ">=14.5.0"
   },
@@ -25,7 +25,7 @@
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
-    "@ministryofjustice/module-alias": "^1.0.20",
+    "@ministryofjustice/module-alias": "^1.0.21",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
[Trello](https://trello.com/c/VSRSkkfz/2187-github-security-risks)
Bump:
- `module-alias 1.0.21`
- `fb-client 2.1.4`